### PR TITLE
Update fork references: textmatelives org + main branch

### DIFF
--- a/Applications/TextMate/resources/AvailableBundles.plist
+++ b/Applications/TextMate/resources/AvailableBundles.plist
@@ -9,8 +9,8 @@
 <dict>
 	<key>uuid</key><string>2BF448A1-9742-4137-80D2-C7AD8D7A0064</string>
 	<key>name</key><string>Ant</string>
-	<key>url</key><string>https://github.com/dayglojesus/ant.tmbundle</string>
-	<key>ref</key><string>python3-port</string>
+	<key>url</key><string>https://github.com/textmatelives/ant.tmbundle</string>
+	<key>ref</key><string>main</string>
 	<key>autoUpdate</key><true/>
 	<key>category</key><string>Build</string>
 			<key>description</key><string>Ant (http://ant.apache.org/) is a Java-based build tool.</string>
@@ -18,8 +18,8 @@
 <dict>
 	<key>uuid</key><string>766FC6D3-539E-4992-BB95-654636D5F990</string>
 	<key>name</key><string>CMake</string>
-	<key>url</key><string>https://github.com/dayglojesus/cmake.tmbundle</string>
-	<key>ref</key><string>remove-legacy-ruby</string>
+	<key>url</key><string>https://github.com/textmatelives/cmake.tmbundle</string>
+	<key>ref</key><string>main</string>
 	<key>autoUpdate</key><true/>
 	<key>category</key><string>Build</string>
 			<key>description</key><string>CMake (http://www.cmake.org/) is an open-source, cross-platform build system.</string>
@@ -27,7 +27,7 @@
 <dict>
 	<key>uuid</key><string>8B9DDBAF-E65C-4E12-FFA7-467D4AA535B1</string>
 	<key>name</key><string>Docker</string>
-	<key>url</key><string>https://github.com/dayglojesus/Docker.tmbundle</string>
+	<key>url</key><string>https://github.com/textmatelives/Docker.tmbundle</string>
 	<key>ref</key><string>master</string>
 	<key>autoUpdate</key><true/>
 	<key>category</key><string>Build</string>
@@ -36,8 +36,8 @@
 <dict>
 	<key>uuid</key><string>ADD9CB84-49C7-4BED-815C-B92340804265</string>
 	<key>name</key><string>Ninja</string>
-	<key>url</key><string>https://github.com/dayglojesus/ninja.tmbundle</string>
-	<key>ref</key><string>remove-legacy-ruby</string>
+	<key>url</key><string>https://github.com/textmatelives/ninja.tmbundle</string>
+	<key>ref</key><string>main</string>
 	<key>autoUpdate</key><true/>
 	<key>category</key><string>Build</string>
 			<key>description</key><string>Build command for ninja (https://ninja-build.org/).</string>
@@ -45,7 +45,7 @@
 <dict>
 	<key>uuid</key><string>FF4C85FD-F635-42B7-B15D-2CB2241AF54D</string>
 	<key>name</key><string>Rave</string>
-	<key>url</key><string>https://github.com/dayglojesus/rave.tmbundle</string>
+	<key>url</key><string>https://github.com/textmatelives/rave.tmbundle</string>
 	<key>ref</key><string>master</string>
 	<key>autoUpdate</key><true/>
 	<key>category</key><string>Build</string>
@@ -54,8 +54,8 @@
 <dict>
 	<key>uuid</key><string>31ACFE4A-592A-41C5-9D23-0C315EC5F7A8</string>
 	<key>name</key><string>SCons</string>
-	<key>url</key><string>https://github.com/dayglojesus/scons.tmbundle</string>
-	<key>ref</key><string>python3-port</string>
+	<key>url</key><string>https://github.com/textmatelives/scons.tmbundle</string>
+	<key>ref</key><string>main</string>
 	<key>autoUpdate</key><true/>
 	<key>category</key><string>Build</string>
 			<key>description</key><string>SCons (http://www.scons.org/) is an Open Source software construction tool—that is, a next-generation build tool. Think of SCons as an improved, cross-platform substitute for the classic Make utility.</string>
@@ -63,8 +63,8 @@
 <dict>
 	<key>uuid</key><string>46758957-6227-11D9-BFB1-000D93589AF6</string>
 	<key>name</key><string>Ada</string>
-	<key>url</key><string>https://github.com/dayglojesus/ada.tmbundle</string>
-	<key>ref</key><string>remove-legacy-ruby</string>
+	<key>url</key><string>https://github.com/textmatelives/ada.tmbundle</string>
+	<key>ref</key><string>main</string>
 	<key>autoUpdate</key><true/>
 	<key>category</key><string>Languages</string>
 			<key>description</key><string>Minimal support for Ada (http://en.wikipedia.org/wiki/Ada_(programming_language)).</string>
@@ -72,7 +72,7 @@
 <dict>
 	<key>uuid</key><string>7F43D670-A808-4D6E-BDE7-8CD71C2396EC</string>
 	<key>name</key><string>ANTLR</string>
-	<key>url</key><string>https://github.com/dayglojesus/antlr.tmbundle</string>
+	<key>url</key><string>https://github.com/textmatelives/antlr.tmbundle</string>
 	<key>ref</key><string>master</string>
 	<key>autoUpdate</key><true/>
 	<key>category</key><string>Languages</string>
@@ -81,8 +81,8 @@
 <dict>
 	<key>uuid</key><string>75DD2785-07CA-46DB-A1FE-C3773484A2D9</string>
 	<key>name</key><string>AppleScript</string>
-	<key>url</key><string>https://github.com/dayglojesus/applescript.tmbundle</string>
-	<key>ref</key><string>remove-legacy-ruby</string>
+	<key>url</key><string>https://github.com/textmatelives/applescript.tmbundle</string>
+	<key>ref</key><string>main</string>
 	<key>autoUpdate</key><true/>
 	<key>category</key><string>Languages</string>
 			<key>description</key><string>Write and run your AppleScripts (http://www.apple.com/macosx/features/applescript/) with this bundle. Contains lots of useful snippets.</string>
@@ -90,8 +90,8 @@
 <dict>
 	<key>uuid</key><string>756D4112-6F27-4633-A716-66EA39794282</string>
 	<key>name</key><string>Arduino</string>
-	<key>url</key><string>https://github.com/dayglojesus/arduino.tmbundle</string>
-	<key>ref</key><string>remove-legacy-ruby</string>
+	<key>url</key><string>https://github.com/textmatelives/arduino.tmbundle</string>
+	<key>ref</key><string>main</string>
 	<key>autoUpdate</key><true/>
 	<key>category</key><string>Languages</string>
 			<key>description</key><string>Syntax highlighting and snippets for Arduino sketches.</string>
@@ -99,7 +99,7 @@
 <dict>
 	<key>uuid</key><string>344D329E-6B21-11D9-B355-000D93589AF6</string>
 	<key>name</key><string>ASP</string>
-	<key>url</key><string>https://github.com/dayglojesus/asp.tmbundle</string>
+	<key>url</key><string>https://github.com/textmatelives/asp.tmbundle</string>
 	<key>ref</key><string>master</string>
 	<key>autoUpdate</key><true/>
 	<key>category</key><string>Languages</string>
@@ -108,7 +108,7 @@
 <dict>
 	<key>uuid</key><string>4F07B982-DA8C-49E5-AB47-3C0C79BE562B</string>
 	<key>name</key><string>ASP vb.NET</string>
-	<key>url</key><string>https://github.com/dayglojesus/asp.vb.net.tmbundle</string>
+	<key>url</key><string>https://github.com/textmatelives/asp.vb.net.tmbundle</string>
 	<key>ref</key><string>master</string>
 	<key>autoUpdate</key><true/>
 	<key>category</key><string>Languages</string>
@@ -117,7 +117,7 @@
 <dict>
 	<key>uuid</key><string>A8A52DF1-BAFB-4071-B738-16CE26F78B0A</string>
 	<key>name</key><string>Bison</string>
-	<key>url</key><string>https://github.com/dayglojesus/bison.tmbundle</string>
+	<key>url</key><string>https://github.com/textmatelives/bison.tmbundle</string>
 	<key>ref</key><string>master</string>
 	<key>autoUpdate</key><true/>
 	<key>category</key><string>Languages</string>
@@ -126,7 +126,7 @@
 <dict>
 	<key>uuid</key><string>5A841EC2-B9E2-4E96-AA2F-D49CAC1F0C4A</string>
 	<key>name</key><string>Bulletin Board</string>
-	<key>url</key><string>https://github.com/dayglojesus/bulletin-board.tmbundle</string>
+	<key>url</key><string>https://github.com/textmatelives/bulletin-board.tmbundle</string>
 	<key>ref</key><string>master</string>
 	<key>autoUpdate</key><true/>
 	<key>category</key><string>Languages</string>
@@ -135,7 +135,7 @@
 <dict>
 	<key>uuid</key><string>66623882-73FB-11D9-85C6-000D93589AF6</string>
 	<key>name</key><string>C#</string>
-	<key>url</key><string>https://github.com/dayglojesus/csharp-tmbundle</string>
+	<key>url</key><string>https://github.com/textmatelives/csharp-tmbundle</string>
 	<key>ref</key><string>master</string>
 	<key>autoUpdate</key><true/>
 	<key>category</key><string>Languages</string>
@@ -144,7 +144,7 @@
 <dict>
 	<key>uuid</key><string>B5EEC818-98AC-486C-B158-966F88511EC0</string>
 	<key>name</key><string>Cap’n Proto</string>
-	<key>url</key><string>https://github.com/dayglojesus/capnproto.tmbundle</string>
+	<key>url</key><string>https://github.com/textmatelives/capnproto.tmbundle</string>
 	<key>ref</key><string>master</string>
 	<key>autoUpdate</key><true/>
 	<key>category</key><string>Languages</string>
@@ -153,8 +153,8 @@
 <dict>
 	<key>uuid</key><string>E65BAFA0-39BA-458F-8D85-ECE6BF9EDF69</string>
 	<key>name</key><string>Elixir</string>
-	<key>url</key><string>https://github.com/dayglojesus/elixir-tmbundle</string>
-	<key>ref</key><string>remove-legacy-ruby</string>
+	<key>url</key><string>https://github.com/textmatelives/elixir-tmbundle</string>
+	<key>ref</key><string>main</string>
 	<key>autoUpdate</key><true/>
 	<key>category</key><string>Languages</string>
 			<key>description</key><string>A dynamic, functional language designed for building scalable and maintainable applications.</string>
@@ -162,7 +162,7 @@
 <dict>
 	<key>uuid</key><string>A29B280D-8D4C-4416-AC5A-97F50669603A</string>
 	<key>name</key><string>F Sharp</string>
-	<key>url</key><string>https://github.com/dayglojesus/f-sharp.tmbundle</string>
+	<key>url</key><string>https://github.com/textmatelives/f-sharp.tmbundle</string>
 	<key>ref</key><string>master</string>
 	<key>autoUpdate</key><true/>
 	<key>category</key><string>Languages</string>
@@ -171,7 +171,7 @@
 <dict>
 	<key>uuid</key><string>AFB88386-F238-4FB6-B476-A6A7E1491A88</string>
 	<key>name</key><string>Forth</string>
-	<key>url</key><string>https://github.com/dayglojesus/forth.tmbundle</string>
+	<key>url</key><string>https://github.com/textmatelives/forth.tmbundle</string>
 	<key>ref</key><string>master</string>
 	<key>autoUpdate</key><true/>
 	<key>category</key><string>Languages</string>
@@ -180,8 +180,8 @@
 <dict>
 	<key>uuid</key><string>1F0EE883-C3DA-4AD4-82F2-6795F0B2CA7B</string>
 	<key>name</key><string>Fortran</string>
-	<key>url</key><string>https://github.com/dayglojesus/fortran.tmbundle</string>
-	<key>ref</key><string>remove-legacy-ruby</string>
+	<key>url</key><string>https://github.com/textmatelives/fortran.tmbundle</string>
+	<key>ref</key><string>main</string>
 	<key>autoUpdate</key><true/>
 	<key>category</key><string>Languages</string>
 			<key>description</key><string>Support for the Fortran (http://en.wikipedia.org/wiki/Fortran) programming language.</string>
@@ -189,7 +189,7 @@
 <dict>
 	<key>uuid</key><string>191B06AB-47B8-4E72-B0DE-291A35D93B99</string>
 	<key>name</key><string>Gettext</string>
-	<key>url</key><string>https://github.com/dayglojesus/gettext.tmbundle</string>
+	<key>url</key><string>https://github.com/textmatelives/gettext.tmbundle</string>
 	<key>ref</key><string>master</string>
 	<key>autoUpdate</key><true/>
 	<key>category</key><string>Languages</string>
@@ -198,8 +198,8 @@
 <dict>
 	<key>uuid</key><string>9A94FED7-9430-410F-9C6A-5B9D48A89180</string>
 	<key>name</key><string>Go</string>
-	<key>url</key><string>https://github.com/dayglojesus/golang.tmbundle</string>
-	<key>ref</key><string>remove-legacy-ruby</string>
+	<key>url</key><string>https://github.com/textmatelives/golang.tmbundle</string>
+	<key>ref</key><string>main</string>
 	<key>autoUpdate</key><true/>
 	<key>category</key><string>Languages</string>
 			<key>description</key><string>Support for the Go programming language (http://golang.org).</string>
@@ -207,7 +207,7 @@
 <dict>
 	<key>uuid</key><string>344D1644-6B21-11D9-B355-000D93589AF6</string>
 	<key>name</key><string>Graphviz</string>
-	<key>url</key><string>https://github.com/dayglojesus/graphviz.tmbundle</string>
+	<key>url</key><string>https://github.com/textmatelives/graphviz.tmbundle</string>
 	<key>ref</key><string>master</string>
 	<key>autoUpdate</key><true/>
 	<key>category</key><string>Languages</string>
@@ -216,7 +216,7 @@
 <dict>
 	<key>uuid</key><string>47889EBB-6E0F-4D16-ADDE-0616D5795636</string>
 	<key>name</key><string>Gri</string>
-	<key>url</key><string>https://github.com/dayglojesus/gri.tmbundle</string>
+	<key>url</key><string>https://github.com/textmatelives/gri.tmbundle</string>
 	<key>ref</key><string>master</string>
 	<key>autoUpdate</key><true/>
 	<key>category</key><string>Languages</string>
@@ -225,8 +225,8 @@
 <dict>
 	<key>uuid</key><string>118557A4-4FEF-406D-A68E-BD191D9CBC83</string>
 	<key>name</key><string>Haskell</string>
-	<key>url</key><string>https://github.com/dayglojesus/haskell.tmbundle</string>
-	<key>ref</key><string>remove-legacy-ruby</string>
+	<key>url</key><string>https://github.com/textmatelives/haskell.tmbundle</string>
+	<key>ref</key><string>main</string>
 	<key>autoUpdate</key><true/>
 	<key>category</key><string>Languages</string>
 			<key>description</key><string>Support for Haskell (http://www.haskell.org/), a general purpose, purely functional programming language featuring static typing, higher order functions, polymorphism, type classes, and monadic effects.</string>
@@ -234,7 +234,7 @@
 <dict>
 	<key>uuid</key><string>46779A0A-6227-11D9-BFB1-000D93589AF6</string>
 	<key>name</key><string>iCalendar</string>
-	<key>url</key><string>https://github.com/dayglojesus/icalendar.tmbundle</string>
+	<key>url</key><string>https://github.com/textmatelives/icalendar.tmbundle</string>
 	<key>ref</key><string>master</string>
 	<key>autoUpdate</key><true/>
 	<key>category</key><string>Languages</string>
@@ -243,7 +243,7 @@
 <dict>
 	<key>uuid</key><string>77B12BEB-8A90-11D9-BAA4-000A9584EC8C</string>
 	<key>name</key><string>Ini</string>
-	<key>url</key><string>https://github.com/dayglojesus/ini.tmbundle</string>
+	<key>url</key><string>https://github.com/textmatelives/ini.tmbundle</string>
 	<key>ref</key><string>master</string>
 	<key>autoUpdate</key><true/>
 	<key>category</key><string>Languages</string>
@@ -252,7 +252,7 @@
 <dict>
 	<key>uuid</key><string>0A5DEA4F-3A77-4CA5-9319-C8F885127572</string>
 	<key>name</key><string>Installer</string>
-	<key>url</key><string>https://github.com/dayglojesus/installer.tmbundle</string>
+	<key>url</key><string>https://github.com/textmatelives/installer.tmbundle</string>
 	<key>ref</key><string>master</string>
 	<key>autoUpdate</key><true/>
 	<key>category</key><string>Languages</string>
@@ -261,7 +261,7 @@
 <dict>
 	<key>uuid</key><string>7F48FD99-8480-47CC-8C4B-F6AD17ACF122</string>
 	<key>name</key><string>iPhone</string>
-	<key>url</key><string>https://github.com/dayglojesus/iphone.tmbundle</string>
+	<key>url</key><string>https://github.com/textmatelives/iphone.tmbundle</string>
 	<key>ref</key><string>master</string>
 	<key>autoUpdate</key><true/>
 	<key>category</key><string>Languages</string>
@@ -270,7 +270,7 @@
 <dict>
 	<key>uuid</key><string>44339853-BBEB-44BF-9E69-B70E8E040B4C</string>
 	<key>name</key><string>Java Velocity</string>
-	<key>url</key><string>https://github.com/dayglojesus/java-velocity.tmbundle</string>
+	<key>url</key><string>https://github.com/textmatelives/java-velocity.tmbundle</string>
 	<key>ref</key><string>master</string>
 	<key>autoUpdate</key><true/>
 	<key>category</key><string>Languages</string>
@@ -279,7 +279,7 @@
 <dict>
 	<key>uuid</key><string>D0C00F56-0B8D-4972-B958-A82E93F95581</string>
 	<key>name</key><string>JavaDoc</string>
-	<key>url</key><string>https://github.com/dayglojesus/javadoc.tmbundle</string>
+	<key>url</key><string>https://github.com/textmatelives/javadoc.tmbundle</string>
 	<key>ref</key><string>master</string>
 	<key>autoUpdate</key><true/>
 	<key>category</key><string>Languages</string>
@@ -288,7 +288,7 @@
 <dict>
 	<key>uuid</key><string>DA18BD22-6C7A-4D77-9100-4511229558D9</string>
 	<key>name</key><string>JavaScript jQuery</string>
-	<key>url</key><string>https://github.com/dayglojesus/jquery-tmbundle</string>
+	<key>url</key><string>https://github.com/textmatelives/jquery-tmbundle</string>
 	<key>ref</key><string>master</string>
 	<key>autoUpdate</key><true/>
 	<key>category</key><string>Languages</string>
@@ -297,7 +297,7 @@
 <dict>
 	<key>uuid</key><string>6FFB94A1-EB29-4A7B-87B7-7E47035CEB79</string>
 	<key>name</key><string>JavaScript JSDoc</string>
-	<key>url</key><string>https://github.com/dayglojesus/javascript-jsdoc.tmbundle</string>
+	<key>url</key><string>https://github.com/textmatelives/javascript-jsdoc.tmbundle</string>
 	<key>ref</key><string>master</string>
 	<key>autoUpdate</key><true/>
 	<key>category</key><string>Languages</string>
@@ -306,7 +306,7 @@
 <dict>
 	<key>uuid</key><string>1FB3D538-84E1-4002-AA46-5705529A27E1</string>
 	<key>name</key><string>JavaScript Objective-J</string>
-	<key>url</key><string>https://github.com/dayglojesus/javascript-objective-j.tmbundle</string>
+	<key>url</key><string>https://github.com/textmatelives/javascript-objective-j.tmbundle</string>
 	<key>ref</key><string>master</string>
 	<key>autoUpdate</key><true/>
 	<key>category</key><string>Languages</string>
@@ -315,8 +315,8 @@
 <dict>
 	<key>uuid</key><string>F123BC73-9B19-4E03-847E-D7E47D1931A3</string>
 	<key>name</key><string>Julia</string>
-	<key>url</key><string>https://github.com/dayglojesus/Julia.tmbundle</string>
-	<key>ref</key><string>remove-legacy-ruby</string>
+	<key>url</key><string>https://github.com/textmatelives/Julia.tmbundle</string>
+	<key>ref</key><string>main</string>
 	<key>autoUpdate</key><true/>
 	<key>category</key><string>Languages</string>
 			<key>description</key><string>Mathematical Computing Language</string>
@@ -324,7 +324,7 @@
 <dict>
 	<key>uuid</key><string>536A270F-F121-4291-9DC4-59B0AEC9281A</string>
 	<key>name</key><string>K</string>
-	<key>url</key><string>https://github.com/dayglojesus/k.tmbundle</string>
+	<key>url</key><string>https://github.com/textmatelives/k.tmbundle</string>
 	<key>ref</key><string>master</string>
 	<key>autoUpdate</key><true/>
 	<key>category</key><string>Languages</string>
@@ -333,8 +333,8 @@
 <dict>
 	<key>uuid</key><string>46788DCE-6227-11D9-BFB1-000D93589AF6</string>
 	<key>name</key><string>LaTeX</string>
-	<key>url</key><string>https://github.com/dayglojesus/latex.tmbundle</string>
-	<key>ref</key><string>arm64-binaries</string>
+	<key>url</key><string>https://github.com/textmatelives/latex.tmbundle</string>
+	<key>ref</key><string>main</string>
 	<key>autoUpdate</key><true/>
 	<key>category</key><string>Languages</string>
 			<key>description</key><string>Support for the LaTeX (http://www.latex-project.org/) typesetting system, the de facto standard for scientific papers.</string>
@@ -342,7 +342,7 @@
 <dict>
 	<key>uuid</key><string>C473C122-592E-4943-9CB0-44F02C24F780</string>
 	<key>name</key><string>LDIF</string>
-	<key>url</key><string>https://github.com/dayglojesus/LDIF.tmbundle</string>
+	<key>url</key><string>https://github.com/textmatelives/LDIF.tmbundle</string>
 	<key>ref</key><string>master</string>
 	<key>autoUpdate</key><true/>
 	<key>category</key><string>Languages</string>
@@ -351,8 +351,8 @@
 <dict>
 	<key>uuid</key><string>D1D51EE5-E89F-4B14-8AE4-FC364E540B47</string>
 	<key>name</key><string>LESS</string>
-	<key>url</key><string>https://github.com/dayglojesus/less.tmbundle</string>
-	<key>ref</key><string>remove-legacy-ruby</string>
+	<key>url</key><string>https://github.com/textmatelives/less.tmbundle</string>
+	<key>ref</key><string>main</string>
 	<key>autoUpdate</key><true/>
 	<key>category</key><string>Languages</string>
 			<key>description</key><string>Extends CSS with dynamic behavior such as variables, mixins, operations and functions.</string>
@@ -360,7 +360,7 @@
 <dict>
 	<key>uuid</key><string>408054F2-BF56-439E-B52F-5EC62ED0A849</string>
 	<key>name</key><string>Lex/Flex</string>
-	<key>url</key><string>https://github.com/dayglojesus/lex-flex.tmbundle</string>
+	<key>url</key><string>https://github.com/textmatelives/lex-flex.tmbundle</string>
 	<key>ref</key><string>master</string>
 	<key>autoUpdate</key><true/>
 	<key>category</key><string>Languages</string>
@@ -369,7 +369,7 @@
 <dict>
 	<key>uuid</key><string>5D9846C9-EB37-4F56-BD7F-F3A6BF8846A0</string>
 	<key>name</key><string>LilyPond</string>
-	<key>url</key><string>https://github.com/dayglojesus/lilypond.tmbundle</string>
+	<key>url</key><string>https://github.com/textmatelives/lilypond.tmbundle</string>
 	<key>ref</key><string>master</string>
 	<key>autoUpdate</key><true/>
 	<key>category</key><string>Languages</string>
@@ -378,7 +378,7 @@
 <dict>
 	<key>uuid</key><string>E61A99D4-248F-4466-BD29-998E6F4E32B7</string>
 	<key>name</key><string>Limbo</string>
-	<key>url</key><string>https://github.com/dayglojesus/limbo.tmbundle</string>
+	<key>url</key><string>https://github.com/textmatelives/limbo.tmbundle</string>
 	<key>ref</key><string>master</string>
 	<key>autoUpdate</key><true/>
 	<key>category</key><string>Languages</string>
@@ -387,7 +387,7 @@
 <dict>
 	<key>uuid</key><string>46790904-6227-11D9-BFB1-000D93589AF6</string>
 	<key>name</key><string>Lisp</string>
-	<key>url</key><string>https://github.com/dayglojesus/lisp.tmbundle</string>
+	<key>url</key><string>https://github.com/textmatelives/lisp.tmbundle</string>
 	<key>ref</key><string>master</string>
 	<key>autoUpdate</key><true/>
 	<key>category</key><string>Languages</string>
@@ -396,7 +396,7 @@
 <dict>
 	<key>uuid</key><string>72FC431C-997D-4CBF-A4F2-66F6638F9CB6</string>
 	<key>name</key><string>Logo</string>
-	<key>url</key><string>https://github.com/dayglojesus/logo.tmbundle</string>
+	<key>url</key><string>https://github.com/textmatelives/logo.tmbundle</string>
 	<key>ref</key><string>master</string>
 	<key>autoUpdate</key><true/>
 	<key>category</key><string>Languages</string>
@@ -405,7 +405,7 @@
 <dict>
 	<key>uuid</key><string>C100CC05-6EDB-11D9-8798-000A95DAA580</string>
 	<key>name</key><string>Logtalk</string>
-	<key>url</key><string>https://github.com/dayglojesus/logtalk.tmbundle</string>
+	<key>url</key><string>https://github.com/textmatelives/logtalk.tmbundle</string>
 	<key>ref</key><string>master</string>
 	<key>autoUpdate</key><true/>
 	<key>category</key><string>Languages</string>
@@ -414,7 +414,7 @@
 <dict>
 	<key>uuid</key><string>E6C0E3CA-DDB8-4491-93DA-5BBC04C95951</string>
 	<key>name</key><string>MacPorts</string>
-	<key>url</key><string>https://github.com/dayglojesus/macports.tmbundle</string>
+	<key>url</key><string>https://github.com/textmatelives/macports.tmbundle</string>
 	<key>ref</key><string>master</string>
 	<key>autoUpdate</key><true/>
 	<key>category</key><string>Languages</string>
@@ -423,8 +423,8 @@
 <dict>
 	<key>uuid</key><string>69766802-226D-4D14-9B7C-CC8E16455CFD</string>
 	<key>name</key><string>Man Pages</string>
-	<key>url</key><string>https://github.com/dayglojesus/man-pages.tmbundle</string>
-	<key>ref</key><string>remove-legacy-ruby</string>
+	<key>url</key><string>https://github.com/textmatelives/man-pages.tmbundle</string>
+	<key>ref</key><string>main</string>
 	<key>autoUpdate</key><true/>
 	<key>category</key><string>Languages</string>
 			<key>description</key><string>Syntax highlight for man pages (http://en.wikipedia.org/wiki/Manual_page_(Unix)) and a few commands.</string>
@@ -432,7 +432,7 @@
 <dict>
 	<key>uuid</key><string>A9CF0E77-E848-417C-90F4-77E1231FF1B9</string>
 	<key>name</key><string>Markdown (GitHub)</string>
-	<key>url</key><string>https://github.com/dayglojesus/GitHub-Markdown.tmbundle</string>
+	<key>url</key><string>https://github.com/textmatelives/GitHub-Markdown.tmbundle</string>
 	<key>ref</key><string>master</string>
 	<key>autoUpdate</key><true/>
 	<key>category</key><string>Languages</string>
@@ -441,8 +441,8 @@
 <dict>
 	<key>uuid</key><string>D2B42D16-FDEB-4079-9293-725312736384</string>
 	<key>name</key><string>Mathematica</string>
-	<key>url</key><string>https://github.com/dayglojesus/mathematica-tmbundle</string>
-	<key>ref</key><string>python3-port</string>
+	<key>url</key><string>https://github.com/textmatelives/mathematica-tmbundle</string>
+	<key>ref</key><string>main</string>
 	<key>autoUpdate</key><true/>
 	<key>category</key><string>Languages</string>
 			<key>description</key><string>Mathematica is a computational software program used in scientific, engineering, and mathematical fields and other areas of technical computing. It is created by Wolfram Research (http://www.wolfram.com/).</string>
@@ -450,8 +450,8 @@
 <dict>
 	<key>uuid</key><string>AF26E7BD-72FF-11D9-B408-000D93589AF6</string>
 	<key>name</key><string>Matlab</string>
-	<key>url</key><string>https://github.com/dayglojesus/matlab.tmbundle</string>
-	<key>ref</key><string>remove-legacy-ruby</string>
+	<key>url</key><string>https://github.com/textmatelives/matlab.tmbundle</string>
+	<key>ref</key><string>main</string>
 	<key>autoUpdate</key><true/>
 	<key>category</key><string>Languages</string>
 			<key>description</key><string>Support for MATLAB (http://www.mathworks.com/products/matlab/), and Octave (http://octave.org), two largely compatible high-level languages that enables you to perform computationally intensive tasks faster than with traditional programming languages.</string>
@@ -459,8 +459,8 @@
 <dict>
 	<key>uuid</key><string>DC431C52-9E0C-49AC-A178-FEF388470627</string>
 	<key>name</key><string>Maude</string>
-	<key>url</key><string>https://github.com/dayglojesus/maude.tmbundle</string>
-	<key>ref</key><string>remove-legacy-ruby</string>
+	<key>url</key><string>https://github.com/textmatelives/maude.tmbundle</string>
+	<key>ref</key><string>main</string>
 	<key>autoUpdate</key><true/>
 	<key>category</key><string>Languages</string>
 			<key>description</key><string>Equational and rewriting logic specification and programming.</string>
@@ -468,8 +468,8 @@
 <dict>
 	<key>uuid</key><string>3BF76C5E-8AB7-4F90-9CEE-79F95D289E6F</string>
 	<key>name</key><string>Maven</string>
-	<key>url</key><string>https://github.com/dayglojesus/maven.tmbundle</string>
-	<key>ref</key><string>remove-legacy-ruby</string>
+	<key>url</key><string>https://github.com/textmatelives/maven.tmbundle</string>
+	<key>ref</key><string>main</string>
 	<key>autoUpdate</key><true/>
 	<key>category</key><string>Languages</string>
 			<key>description</key><string>Support for working with Maven (http://maven.apache.org/) based projects.</string>
@@ -477,7 +477,7 @@
 <dict>
 	<key>uuid</key><string>64C4222F-7054-4A26-B91E-A82F53166142</string>
 	<key>name</key><string>Mediawiki</string>
-	<key>url</key><string>https://github.com/dayglojesus/mediawiki.tmbundle</string>
+	<key>url</key><string>https://github.com/textmatelives/mediawiki.tmbundle</string>
 	<key>ref</key><string>master</string>
 	<key>autoUpdate</key><true/>
 	<key>category</key><string>Languages</string>
@@ -486,8 +486,8 @@
 <dict>
 	<key>uuid</key><string>402D341A-6BE4-11D9-AEC0-0011242E4184</string>
 	<key>name</key><string>MIPS Assembler</string>
-	<key>url</key><string>https://github.com/dayglojesus/mips.tmbundle</string>
-	<key>ref</key><string>remove-legacy-ruby</string>
+	<key>url</key><string>https://github.com/textmatelives/mips.tmbundle</string>
+	<key>ref</key><string>main</string>
 	<key>autoUpdate</key><true/>
 	<key>category</key><string>Languages</string>
 			<key>description</key><string>Support for MIPS assembler (http://en.wikibooks.org/wiki/Programming:MIPS_assembly).</string>
@@ -495,7 +495,7 @@
 <dict>
 	<key>uuid</key><string>005ECD5C-8762-4E90-8D8F-C778C91FFB66</string>
 	<key>name</key><string>Movable Type</string>
-	<key>url</key><string>https://github.com/dayglojesus/movable-type.tmbundle</string>
+	<key>url</key><string>https://github.com/textmatelives/movable-type.tmbundle</string>
 	<key>ref</key><string>master</string>
 	<key>autoUpdate</key><true/>
 	<key>category</key><string>Languages</string>
@@ -504,7 +504,7 @@
 <dict>
 	<key>uuid</key><string>5B1D8959-F6BB-4F99-9E28-C97BFF447DF6</string>
 	<key>name</key><string>Mx</string>
-	<key>url</key><string>https://github.com/dayglojesus/mx.tmbundle</string>
+	<key>url</key><string>https://github.com/textmatelives/mx.tmbundle</string>
 	<key>ref</key><string>master</string>
 	<key>autoUpdate</key><true/>
 	<key>category</key><string>Languages</string>
@@ -513,8 +513,8 @@
 <dict>
 	<key>uuid</key><string>126B2BEF-74BC-4D2F-907F-95C4A05A7A04</string>
 	<key>name</key><string>Nim</string>
-	<key>url</key><string>https://github.com/dayglojesus/nim.tmbundle</string>
-	<key>ref</key><string>remove-legacy-ruby</string>
+	<key>url</key><string>https://github.com/textmatelives/nim.tmbundle</string>
+	<key>ref</key><string>main</string>
 	<key>autoUpdate</key><true/>
 	<key>category</key><string>Languages</string>
 			<key>description</key><string>Statically typed, imperative programming language</string>
@@ -522,7 +522,7 @@
 <dict>
 	<key>uuid</key><string>8E974139-4838-4E8E-B70E-0A552EB9760E</string>
 	<key>name</key><string>OpenGL</string>
-	<key>url</key><string>https://github.com/dayglojesus/opengl.tmbundle</string>
+	<key>url</key><string>https://github.com/textmatelives/opengl.tmbundle</string>
 	<key>ref</key><string>master</string>
 	<key>autoUpdate</key><true/>
 	<key>category</key><string>Languages</string>
@@ -531,7 +531,7 @@
 <dict>
 	<key>uuid</key><string>2CD058CC-E5E2-41BC-8FF8-0C2BFC043F3E</string>
 	<key>name</key><string>OpenMx</string>
-	<key>url</key><string>https://github.com/dayglojesus/OpenMx.tmbundle</string>
+	<key>url</key><string>https://github.com/textmatelives/OpenMx.tmbundle</string>
 	<key>ref</key><string>master</string>
 	<key>autoUpdate</key><true/>
 	<key>category</key><string>Languages</string>
@@ -540,7 +540,7 @@
 <dict>
 	<key>uuid</key><string>3086DFC6-6DEA-461E-9137-257B18408D56</string>
 	<key>name</key><string>Parrot</string>
-	<key>url</key><string>https://github.com/dayglojesus/parrot.tmbundle</string>
+	<key>url</key><string>https://github.com/textmatelives/parrot.tmbundle</string>
 	<key>ref</key><string>master</string>
 	<key>autoUpdate</key><true/>
 	<key>category</key><string>Languages</string>
@@ -549,7 +549,7 @@
 <dict>
 	<key>uuid</key><string>46799436-6227-11D9-BFB1-000D93589AF6</string>
 	<key>name</key><string>Pascal</string>
-	<key>url</key><string>https://github.com/dayglojesus/pascal.tmbundle</string>
+	<key>url</key><string>https://github.com/textmatelives/pascal.tmbundle</string>
 	<key>ref</key><string>master</string>
 	<key>autoUpdate</key><true/>
 	<key>category</key><string>Languages</string>
@@ -558,8 +558,8 @@
 <dict>
 	<key>uuid</key><string>B3167F84-4734-4693-AA6E-A3EBFB36B9E0</string>
 	<key>name</key><string>PDB</string>
-	<key>url</key><string>https://github.com/dayglojesus/pdb.tmbundle</string>
-	<key>ref</key><string>python3-port</string>
+	<key>url</key><string>https://github.com/textmatelives/pdb.tmbundle</string>
+	<key>ref</key><string>main</string>
 	<key>autoUpdate</key><true/>
 	<key>category</key><string>Languages</string>
 			<key>description</key><string>Bundle for the manipulation of RCSB or pseudo-RCSB PDB structure files.</string>
@@ -567,7 +567,7 @@
 <dict>
 	<key>uuid</key><string>5A67ADDC-283A-4E0F-AA36-29E4E95B4A26</string>
 	<key>name</key><string>Perl HTML::Template</string>
-	<key>url</key><string>https://github.com/dayglojesus/perl-html-template.tmbundle</string>
+	<key>url</key><string>https://github.com/textmatelives/perl-html-template.tmbundle</string>
 	<key>ref</key><string>master</string>
 	<key>autoUpdate</key><true/>
 	<key>category</key><string>Languages</string>
@@ -576,7 +576,7 @@
 <dict>
 	<key>uuid</key><string>73C53C31-8AFA-4369-A92F-E5D6904EF628</string>
 	<key>name</key><string>Postscript</string>
-	<key>url</key><string>https://github.com/dayglojesus/postscript.tmbundle</string>
+	<key>url</key><string>https://github.com/textmatelives/postscript.tmbundle</string>
 	<key>ref</key><string>master</string>
 	<key>autoUpdate</key><true/>
 	<key>category</key><string>Languages</string>
@@ -585,8 +585,8 @@
 <dict>
 	<key>uuid</key><string>DC9271C5-8267-4C5F-93A9-3E3FFC741BEA</string>
 	<key>name</key><string>Processing</string>
-	<key>url</key><string>https://github.com/dayglojesus/processing.tmbundle</string>
-	<key>ref</key><string>remove-legacy-ruby</string>
+	<key>url</key><string>https://github.com/textmatelives/processing.tmbundle</string>
+	<key>ref</key><string>main</string>
 	<key>autoUpdate</key><true/>
 	<key>category</key><string>Languages</string>
 			<key>description</key><string>Processing (http://processing.org/) is an open source programming language and environment for people who want to program images, animation, and sound.</string>
@@ -594,8 +594,8 @@
 <dict>
 	<key>uuid</key><string>101B21C6-132C-4811-BDCF-2B028860F681</string>
 	<key>name</key><string>Prolog</string>
-	<key>url</key><string>https://github.com/dayglojesus/prolog.tmbundle</string>
-	<key>ref</key><string>remove-legacy-ruby</string>
+	<key>url</key><string>https://github.com/textmatelives/prolog.tmbundle</string>
+	<key>ref</key><string>main</string>
 	<key>autoUpdate</key><true/>
 	<key>category</key><string>Languages</string>
 			<key>description</key><string>Prolog (http://en.wikipedia.org/wiki/Prolog) is a logic programming language. It is a general purpose language, which is especially associated with artificial intelligence and computational linguistics.</string>
@@ -603,8 +603,8 @@
 <dict>
 	<key>uuid</key><string>04734303-952E-44C6-BC53-650D4409E3BE</string>
 	<key>name</key><string>Python Django</string>
-	<key>url</key><string>https://github.com/dayglojesus/python-django.tmbundle</string>
-	<key>ref</key><string>remove-legacy-ruby</string>
+	<key>url</key><string>https://github.com/textmatelives/python-django.tmbundle</string>
+	<key>ref</key><string>main</string>
 	<key>autoUpdate</key><true/>
 	<key>category</key><string>Languages</string>
 			<key>description</key><string>Support for the Django web framework (http://www.djangoproject.com/) (Python).</string>
@@ -612,7 +612,7 @@
 <dict>
 	<key>uuid</key><string>230EB053-6E5D-11D9-BE5A-0011242E4184</string>
 	<key>name</key><string>Quake</string>
-	<key>url</key><string>https://github.com/dayglojesus/quake.tmbundle</string>
+	<key>url</key><string>https://github.com/textmatelives/quake.tmbundle</string>
 	<key>ref</key><string>master</string>
 	<key>autoUpdate</key><true/>
 	<key>category</key><string>Languages</string>
@@ -621,8 +621,8 @@
 <dict>
 	<key>uuid</key><string>B29D7850-6E70-11D9-A369-000D93B3A10E</string>
 	<key>name</key><string>R</string>
-	<key>url</key><string>https://github.com/dayglojesus/r.tmbundle</string>
-	<key>ref</key><string>remove-legacy-ruby</string>
+	<key>url</key><string>https://github.com/textmatelives/r.tmbundle</string>
+	<key>ref</key><string>main</string>
 	<key>autoUpdate</key><true/>
 	<key>category</key><string>Languages</string>
 			<key>description</key><string>R (http://www.r-project.org/) is a free software environment for statistical computing and graphics. This bundle includes a command that sends current line to the R.app environment or to the Rdaemon.</string>
@@ -630,7 +630,7 @@
 <dict>
 	<key>uuid</key><string>CE1CE629-A9D6-4918-94C9-824D527276FD</string>
 	<key>name</key><string>Ragel</string>
-	<key>url</key><string>https://github.com/dayglojesus/ragel.tmbundle</string>
+	<key>url</key><string>https://github.com/textmatelives/ragel.tmbundle</string>
 	<key>ref</key><string>master</string>
 	<key>autoUpdate</key><true/>
 	<key>category</key><string>Languages</string>
@@ -639,7 +639,7 @@
 <dict>
 	<key>uuid</key><string>B5254936-065A-4E65-8F58-3540179AC959</string>
 	<key>name</key><string>Rez</string>
-	<key>url</key><string>https://github.com/dayglojesus/rez.tmbundle</string>
+	<key>url</key><string>https://github.com/textmatelives/rez.tmbundle</string>
 	<key>ref</key><string>master</string>
 	<key>autoUpdate</key><true/>
 	<key>category</key><string>Languages</string>
@@ -648,7 +648,7 @@
 <dict>
 	<key>uuid</key><string>4618480A-F4C3-40FE-8719-DE54CBDFB92A</string>
 	<key>name</key><string>Ruby Haml</string>
-	<key>url</key><string>https://github.com/dayglojesus/ruby-haml.tmbundle</string>
+	<key>url</key><string>https://github.com/textmatelives/ruby-haml.tmbundle</string>
 	<key>ref</key><string>master</string>
 	<key>autoUpdate</key><true/>
 	<key>category</key><string>Languages</string>
@@ -657,8 +657,8 @@
 <dict>
 	<key>uuid</key><string>467A60E0-6227-11D9-BFB1-000D93589AF6</string>
 	<key>name</key><string>Ruby on Rails</string>
-	<key>url</key><string>https://github.com/dayglojesus/ruby-on-rails-tmbundle</string>
-	<key>ref</key><string>remove-legacy-ruby</string>
+	<key>url</key><string>https://github.com/textmatelives/ruby-on-rails-tmbundle</string>
+	<key>ref</key><string>main</string>
 	<key>autoUpdate</key><true/>
 	<key>category</key><string>Languages</string>
 			<key>description</key><string>Ruby on Rails (http://www.rubyonrails.com/) is a full-stack framework for developing database-backed web applications, in Ruby, according to the Model-View-Control pattern.</string>
@@ -666,7 +666,7 @@
 <dict>
 	<key>uuid</key><string>176253C8-5D97-4C20-AA34-3BE8BC73FBC9</string>
 	<key>name</key><string>Ruby Sass</string>
-	<key>url</key><string>https://github.com/dayglojesus/ruby-sass.tmbundle</string>
+	<key>url</key><string>https://github.com/textmatelives/ruby-sass.tmbundle</string>
 	<key>ref</key><string>master</string>
 	<key>autoUpdate</key><true/>
 	<key>category</key><string>Languages</string>
@@ -675,7 +675,7 @@
 <dict>
 	<key>uuid</key><string>8EDBE2CA-575A-42BC-9F36-BD4C99B4DE56</string>
 	<key>name</key><string>Ruby Shoulda</string>
-	<key>url</key><string>https://github.com/dayglojesus/ruby-shoulda.tmbundle</string>
+	<key>url</key><string>https://github.com/textmatelives/ruby-shoulda.tmbundle</string>
 	<key>ref</key><string>master</string>
 	<key>autoUpdate</key><true/>
 	<key>category</key><string>Languages</string>
@@ -684,7 +684,7 @@
 <dict>
 	<key>uuid</key><string>A24283A1-6C91-4CDB-80C5-DC606ED62F04</string>
 	<key>name</key><string>Ruby Slim</string>
-	<key>url</key><string>https://github.com/dayglojesus/ruby-slim.tmbundle</string>
+	<key>url</key><string>https://github.com/textmatelives/ruby-slim.tmbundle</string>
 	<key>ref</key><string>master</string>
 	<key>autoUpdate</key><true/>
 	<key>category</key><string>Languages</string>
@@ -693,8 +693,8 @@
 <dict>
 	<key>uuid</key><string>06794A1F-20AC-457C-AD92-A4A8EF83EB0E</string>
 	<key>name</key><string>Rust</string>
-	<key>url</key><string>https://github.com/dayglojesus/rust.tmbundle</string>
-	<key>ref</key><string>remove-legacy-ruby</string>
+	<key>url</key><string>https://github.com/textmatelives/rust.tmbundle</string>
+	<key>ref</key><string>main</string>
 	<key>autoUpdate</key><true/>
 	<key>category</key><string>Languages</string>
 			<key>description</key><string>A general-purpose, multi-paradigm, compiled programming language developed by Mozilla Research.</string>
@@ -702,8 +702,8 @@
 <dict>
 	<key>uuid</key><string>D0DEBECD-4A14-485C-B628-7ECB0260A8A1</string>
 	<key>name</key><string>Scala</string>
-	<key>url</key><string>https://github.com/dayglojesus/scala.tmbundle</string>
-	<key>ref</key><string>arm64-binaries</string>
+	<key>url</key><string>https://github.com/textmatelives/scala.tmbundle</string>
+	<key>ref</key><string>main</string>
 	<key>autoUpdate</key><true/>
 	<key>category</key><string>Languages</string>
 			<key>description</key><string>A type-safe Java VM language incorporating both object oriented and functional programming.</string>
@@ -711,8 +711,8 @@
 <dict>
 	<key>uuid</key><string>582E3655-382D-47BE-BB71-AB11E4286D0A</string>
 	<key>name</key><string>Scheme</string>
-	<key>url</key><string>https://github.com/dayglojesus/scheme.tmbundle</string>
-	<key>ref</key><string>remove-legacy-ruby</string>
+	<key>url</key><string>https://github.com/textmatelives/scheme.tmbundle</string>
+	<key>ref</key><string>main</string>
 	<key>autoUpdate</key><true/>
 	<key>category</key><string>Languages</string>
 			<key>description</key><string>Scheme (http://www-swiss.ai.mit.edu/projects/scheme/) is a statically scoped and properly tail-recursive dialect of the Lisp programming language.</string>
@@ -720,7 +720,7 @@
 <dict>
 	<key>uuid</key><string>C397B72C-7519-44CD-8533-7AB7F701C4E4</string>
 	<key>name</key><string>Scilab</string>
-	<key>url</key><string>https://github.com/dayglojesus/scilab.tmbundle</string>
+	<key>url</key><string>https://github.com/textmatelives/scilab.tmbundle</string>
 	<key>ref</key><string>master</string>
 	<key>autoUpdate</key><true/>
 	<key>category</key><string>Languages</string>
@@ -729,7 +729,7 @@
 <dict>
 	<key>uuid</key><string>BCEB5483-E029-479F-95AC-D6AADF98138F</string>
 	<key>name</key><string>SCSS</string>
-	<key>url</key><string>https://github.com/dayglojesus/SCSS.tmbundle</string>
+	<key>url</key><string>https://github.com/textmatelives/SCSS.tmbundle</string>
 	<key>ref</key><string>master</string>
 	<key>autoUpdate</key><true/>
 	<key>category</key><string>Languages</string>
@@ -738,7 +738,7 @@
 <dict>
 	<key>uuid</key><string>7471537C-4EC6-4CCF-B93A-F087986CA465</string>
 	<key>name</key><string>Smalltalk</string>
-	<key>url</key><string>https://github.com/dayglojesus/smalltalk-tmbundle</string>
+	<key>url</key><string>https://github.com/textmatelives/smalltalk-tmbundle</string>
 	<key>ref</key><string>master</string>
 	<key>autoUpdate</key><true/>
 	<key>category</key><string>Languages</string>
@@ -747,7 +747,7 @@
 <dict>
 	<key>uuid</key><string>7A3C2CE9-C65D-4116-92B7-F10D684B1ED6</string>
 	<key>name</key><string>SSH Config</string>
-	<key>url</key><string>https://github.com/dayglojesus/ssh-config.tmbundle</string>
+	<key>url</key><string>https://github.com/textmatelives/ssh-config.tmbundle</string>
 	<key>ref</key><string>master</string>
 	<key>autoUpdate</key><true/>
 	<key>category</key><string>Languages</string>
@@ -756,8 +756,8 @@
 <dict>
 	<key>uuid</key><string>D08F016D-1D07-4BD8-8339-9AB5D151DF31</string>
 	<key>name</key><string>Swift</string>
-	<key>url</key><string>https://github.com/dayglojesus/swift.tmbundle</string>
-	<key>ref</key><string>remove-legacy-ruby</string>
+	<key>url</key><string>https://github.com/textmatelives/swift.tmbundle</string>
+	<key>ref</key><string>main</string>
 	<key>autoUpdate</key><true/>
 	<key>category</key><string>Languages</string>
 			<key>description</key><string>Swift is a general-purpose programming language developed by Apple and built for safety, clarity, and performance.</string>
@@ -765,7 +765,7 @@
 <dict>
 	<key>uuid</key><string>8C563B34-BE0B-11D9-B4D9-000393A143CC</string>
 	<key>name</key><string>SWIG</string>
-	<key>url</key><string>https://github.com/dayglojesus/swig.tmbundle</string>
+	<key>url</key><string>https://github.com/textmatelives/swig.tmbundle</string>
 	<key>ref</key><string>master</string>
 	<key>autoUpdate</key><true/>
 	<key>category</key><string>Languages</string>
@@ -774,7 +774,7 @@
 <dict>
 	<key>uuid</key><string>D587784E-13B0-4090-BF67-42717CC5F89F</string>
 	<key>name</key><string>Tabular</string>
-	<key>url</key><string>https://github.com/dayglojesus/tabular.tmbundle</string>
+	<key>url</key><string>https://github.com/textmatelives/tabular.tmbundle</string>
 	<key>ref</key><string>master</string>
 	<key>autoUpdate</key><true/>
 	<key>category</key><string>Languages</string>
@@ -783,8 +783,8 @@
 <dict>
 	<key>uuid</key><string>7298A864-0E56-48F7-B281-EC3CB338EA4D</string>
 	<key>name</key><string>Tads 3</string>
-	<key>url</key><string>https://github.com/dayglojesus/tads3.tmbundle</string>
-	<key>ref</key><string>remove-legacy-ruby</string>
+	<key>url</key><string>https://github.com/textmatelives/tads3.tmbundle</string>
+	<key>ref</key><string>main</string>
 	<key>autoUpdate</key><true/>
 	<key>category</key><string>Languages</string>
 			<key>description</key><string>Text Adventure Development System, for creating interactive fiction (IF) games.</string>
@@ -792,7 +792,7 @@
 <dict>
 	<key>uuid</key><string>49882962-7CB7-11D9-875B-000A95E13C98</string>
 	<key>name</key><string>Tcl</string>
-	<key>url</key><string>https://github.com/dayglojesus/tcl.tmbundle</string>
+	<key>url</key><string>https://github.com/textmatelives/tcl.tmbundle</string>
 	<key>ref</key><string>master</string>
 	<key>autoUpdate</key><true/>
 	<key>category</key><string>Languages</string>
@@ -801,7 +801,7 @@
 <dict>
 	<key>uuid</key><string>19FB3BCA-1F8A-432D-B201-DE249A121059</string>
 	<key>name</key><string>Terraform</string>
-	<key>url</key><string>https://github.com/dayglojesus/Terraform.tmbundle</string>
+	<key>url</key><string>https://github.com/textmatelives/Terraform.tmbundle</string>
 	<key>ref</key><string>master</string>
 	<key>autoUpdate</key><true/>
 	<key>category</key><string>Languages</string>
@@ -810,8 +810,8 @@
 <dict>
 	<key>uuid</key><string>E6858C0B-B2C9-4A39-A2D6-6D8360A923D0</string>
 	<key>name</key><string>Textile</string>
-	<key>url</key><string>https://github.com/dayglojesus/textile.tmbundle</string>
-	<key>ref</key><string>remove-legacy-ruby</string>
+	<key>url</key><string>https://github.com/textmatelives/textile.tmbundle</string>
+	<key>ref</key><string>main</string>
 	<key>autoUpdate</key><true/>
 	<key>category</key><string>Languages</string>
 			<key>description</key><string>Textile (http://www.textism.com/tools/textile/) is a lightweight markup language originally developed by Dean Allen and billed as a “humane Web text generator”. Textile converts its marked-up text input to valid, well-formed XHTML.</string>
@@ -819,7 +819,7 @@
 <dict>
 	<key>uuid</key><string>4A6C024E-8B12-4119-B7FF-73B10864C7F7</string>
 	<key>name</key><string>Treetop</string>
-	<key>url</key><string>https://github.com/dayglojesus/treetop.tmbundle</string>
+	<key>url</key><string>https://github.com/textmatelives/treetop.tmbundle</string>
 	<key>ref</key><string>master</string>
 	<key>autoUpdate</key><true/>
 	<key>category</key><string>Languages</string>
@@ -828,8 +828,8 @@
 <dict>
 	<key>uuid</key><string>2A796C75-A17D-4EF4-9B1F-2EB6F485E278</string>
 	<key>name</key><string>Txt2tags</string>
-	<key>url</key><string>https://github.com/dayglojesus/txt2tags.tmbundle</string>
-	<key>ref</key><string>python3-port</string>
+	<key>url</key><string>https://github.com/textmatelives/txt2tags.tmbundle</string>
+	<key>ref</key><string>main</string>
 	<key>autoUpdate</key><true/>
 	<key>category</key><string>Languages</string>
 			<key>description</key><string>Txt2tags (http://txt2tags.sourceforge.net) converts text files with minimal markup to HTML, XHTML, SGML, LaTeX, Lout, Man page, Wikipedia, Google Code Wiki, DokuWiki, MoinMoin, MagicPoint and PageMaker.</string>
@@ -837,7 +837,7 @@
 <dict>
 	<key>uuid</key><string>1A78F224-6213-41FB-A7AB-8C17F6BC196D</string>
 	<key>name</key><string>Vectorscript</string>
-	<key>url</key><string>https://github.com/dayglojesus/vectorscript.tmbundle</string>
+	<key>url</key><string>https://github.com/textmatelives/vectorscript.tmbundle</string>
 	<key>ref</key><string>master</string>
 	<key>autoUpdate</key><true/>
 	<key>category</key><string>Languages</string>
@@ -846,7 +846,7 @@
 <dict>
 	<key>uuid</key><string>49BC43A3-4562-4B87-8B43-38ABDA4C8E6B</string>
 	<key>name</key><string>Verilog</string>
-	<key>url</key><string>https://github.com/dayglojesus/verilog.tmbundle</string>
+	<key>url</key><string>https://github.com/textmatelives/verilog.tmbundle</string>
 	<key>ref</key><string>master</string>
 	<key>autoUpdate</key><true/>
 	<key>category</key><string>Languages</string>
@@ -855,7 +855,7 @@
 <dict>
 	<key>uuid</key><string>F5351E61-488E-44A5-BF0B-02FED526B641</string>
 	<key>name</key><string>VHDL</string>
-	<key>url</key><string>https://github.com/dayglojesus/vhdl.tmbundle</string>
+	<key>url</key><string>https://github.com/textmatelives/vhdl.tmbundle</string>
 	<key>ref</key><string>master</string>
 	<key>autoUpdate</key><true/>
 	<key>category</key><string>Languages</string>
@@ -864,7 +864,7 @@
 <dict>
 	<key>uuid</key><string>7CF5FE7E-92F6-4E4E-A4CA-6C876E319910</string>
 	<key>name</key><string>XQuery</string>
-	<key>url</key><string>https://github.com/dayglojesus/xquery.tmbundle</string>
+	<key>url</key><string>https://github.com/textmatelives/xquery.tmbundle</string>
 	<key>ref</key><string>master</string>
 	<key>autoUpdate</key><true/>
 	<key>category</key><string>Languages</string>
@@ -873,8 +873,8 @@
 <dict>
 	<key>uuid</key><string>752DC2FC-D3F0-4DA0-A340-82114D999280</string>
 	<key>name</key><string>Licenses</string>
-	<key>url</key><string>https://github.com/dayglojesus/licenses.tmbundle</string>
-	<key>ref</key><string>remove-legacy-ruby</string>
+	<key>url</key><string>https://github.com/textmatelives/licenses.tmbundle</string>
+	<key>ref</key><string>main</string>
 	<key>autoUpdate</key><true/>
 	<key>category</key><string>Other</string>
 			<key>description</key><string>Insert various open source licenses</string>
@@ -882,7 +882,7 @@
 <dict>
 	<key>uuid</key><string>4F9ED080-B8B8-11D9-AE51-000393A143CC</string>
 	<key>name</key><string>ODCompletion</string>
-	<key>url</key><string>https://github.com/dayglojesus/odcompletion.tmbundle</string>
+	<key>url</key><string>https://github.com/textmatelives/odcompletion.tmbundle</string>
 	<key>ref</key><string>master</string>
 	<key>autoUpdate</key><true/>
 	<key>category</key><string>Other</string>
@@ -891,7 +891,7 @@
 <dict>
 	<key>uuid</key><string>13FEBB9E-8300-11D9-B216-000D9332809C</string>
 	<key>name</key><string>Outlines</string>
-	<key>url</key><string>https://github.com/dayglojesus/outlines.tmbundle</string>
+	<key>url</key><string>https://github.com/textmatelives/outlines.tmbundle</string>
 	<key>ref</key><string>master</string>
 	<key>autoUpdate</key><true/>
 	<key>category</key><string>Other</string>
@@ -900,8 +900,8 @@
 <dict>
 	<key>uuid</key><string>57D5EDA2-A531-11D9-917B-000D9332809C</string>
 	<key>name</key><string>Regular Expressions</string>
-	<key>url</key><string>https://github.com/dayglojesus/regularexpressions.tmbundle</string>
-	<key>ref</key><string>remove-legacy-ruby</string>
+	<key>url</key><string>https://github.com/textmatelives/regularexpressions.tmbundle</string>
+	<key>ref</key><string>main</string>
 	<key>autoUpdate</key><true/>
 	<key>category</key><string>Other</string>
 			<key>description</key><string>Miscellaneous support for working with regular expressions (http://www.regular-expressions.info/).</string>
@@ -909,8 +909,8 @@
 <dict>
 	<key>uuid</key><string>0DCB3E28-8D02-47B0-9D94-2DCC1473A533</string>
 	<key>name</key><string>Unicode</string>
-	<key>url</key><string>https://github.com/dayglojesus/unicode.tmbundle</string>
-	<key>ref</key><string>python3-port</string>
+	<key>url</key><string>https://github.com/textmatelives/unicode.tmbundle</string>
+	<key>ref</key><string>main</string>
 	<key>autoUpdate</key><true/>
 	<key>category</key><string>Other</string>
 			<key>description</key><string>Bundle concerning commands, scripts, etc. to deal with general Unicode resp. non-ASCII related tasks such as: Unicode normalizations, conversion to similar characters, Unicode/IPA character inserting, Unicode properties (incl. Japanese and Chinese characters), conversions of Japanese and Chinese characters, highlighting of non-ASCII characters, displaying the character inventory of the current document, etc.</string>
@@ -918,8 +918,8 @@
 <dict>
 	<key>uuid</key><string>62385B90-7E47-4D43-B44D-63B0BC00FAD3</string>
 	<key>name</key><string>Vagrant</string>
-	<key>url</key><string>https://github.com/dayglojesus/vagrant.tmbundle</string>
-	<key>ref</key><string>remove-legacy-ruby</string>
+	<key>url</key><string>https://github.com/textmatelives/vagrant.tmbundle</string>
+	<key>ref</key><string>main</string>
 	<key>autoUpdate</key><true/>
 	<key>category</key><string>Other</string>
 			<key>description</key><string>Control a vagrant environment</string>
@@ -927,7 +927,7 @@
 <dict>
 	<key>uuid</key><string>95761F74-1A3D-4B51-BA03-41537C38C792</string>
 	<key>name</key><string>FileMerge</string>
-	<key>url</key><string>https://github.com/dayglojesus/filemerge.tmbundle</string>
+	<key>url</key><string>https://github.com/textmatelives/filemerge.tmbundle</string>
 	<key>ref</key><string>master</string>
 	<key>autoUpdate</key><true/>
 	<key>category</key><string>SCM</string>
@@ -936,7 +936,7 @@
 <dict>
 	<key>uuid</key><string>9ADE27C6-4432-449C-9D4C-B5FEC8D33ACA</string>
 	<key>name</key><string>CxxTest</string>
-	<key>url</key><string>https://github.com/dayglojesus/cxxtest.tmbundle</string>
+	<key>url</key><string>https://github.com/textmatelives/cxxtest.tmbundle</string>
 	<key>ref</key><string>master</string>
 	<key>autoUpdate</key><true/>
 	<key>category</key><string>Testing</string>
@@ -945,7 +945,7 @@
 <dict>
 	<key>uuid</key><string>64D20B78-A6BB-4120-B794-00D909680D8D</string>
 	<key>name</key><string>Objective-C Unit Testing</string>
-	<key>url</key><string>https://github.com/dayglojesus/objective-c-unit-testing.tmbundle</string>
+	<key>url</key><string>https://github.com/textmatelives/objective-c-unit-testing.tmbundle</string>
 	<key>ref</key><string>master</string>
 	<key>autoUpdate</key><true/>
 	<key>category</key><string>Testing</string>
@@ -954,8 +954,8 @@
 <dict>
 	<key>uuid</key><string>4CEA47CC-2C3A-45FB-80BE-3820828227C2</string>
 	<key>name</key><string>RSpec</string>
-	<key>url</key><string>https://github.com/dayglojesus/rspec.tmbundle</string>
-	<key>ref</key><string>remove-legacy-ruby</string>
+	<key>url</key><string>https://github.com/textmatelives/rspec.tmbundle</string>
+	<key>ref</key><string>main</string>
 	<key>autoUpdate</key><true/>
 	<key>category</key><string>Testing</string>
 			<key>description</key><string>Behavior-driven development (BDD) framework for the Ruby programming language.</string>
@@ -963,7 +963,7 @@
 <dict>
 	<key>uuid</key><string>C09480C2-10EC-4076-BC5D-281F96917C6B</string>
 	<key>name</key><string>LaTeX Font Settings</string>
-	<key>url</key><string>https://github.com/dayglojesus/LaTeX-Font-Settings.tmbundle</string>
+	<key>url</key><string>https://github.com/textmatelives/LaTeX-Font-Settings.tmbundle</string>
 	<key>ref</key><string>master</string>
 	<key>autoUpdate</key><true/>
 	<key>category</key><string>Themes</string>
@@ -972,7 +972,7 @@
 <dict>
 	<key>uuid</key><string>BC5DE172-1E1A-457C-8807-0B958DDE5B2D</string>
 	<key>name</key><string>Made of Code</string>
-	<key>url</key><string>https://github.com/dayglojesus/made-of-code-tmbundle</string>
+	<key>url</key><string>https://github.com/textmatelives/made-of-code-tmbundle</string>
 	<key>ref</key><string>master</string>
 	<key>autoUpdate</key><true/>
 	<key>category</key><string>Themes</string>
@@ -981,7 +981,7 @@
 <dict>
 	<key>uuid</key><string>91ABC535-7C8F-46B0-92E0-570A73450604</string>
 	<key>name</key><string>Markdown (GitHub) Font Settings</string>
-	<key>url</key><string>https://github.com/dayglojesus/GitHub-Markdown-Font-Settings.tmbundle</string>
+	<key>url</key><string>https://github.com/textmatelives/GitHub-Markdown-Font-Settings.tmbundle</string>
 	<key>ref</key><string>master</string>
 	<key>autoUpdate</key><true/>
 	<key>category</key><string>Themes</string>
@@ -990,7 +990,7 @@
 <dict>
 	<key>uuid</key><string>F019CDBF-4AFC-4CD0-8EFF-A78FAD2FCB5E</string>
 	<key>name</key><string>Monokai</string>
-	<key>url</key><string>https://github.com/dayglojesus/monokai.tmbundle</string>
+	<key>url</key><string>https://github.com/textmatelives/monokai.tmbundle</string>
 	<key>ref</key><string>master</string>
 	<key>autoUpdate</key><true/>
 	<key>category</key><string>Themes</string>

--- a/Applications/TextMate/resources/AvailableBundles.plist
+++ b/Applications/TextMate/resources/AvailableBundles.plist
@@ -28,7 +28,7 @@
 	<key>uuid</key><string>8B9DDBAF-E65C-4E12-FFA7-467D4AA535B1</string>
 	<key>name</key><string>Docker</string>
 	<key>url</key><string>https://github.com/textmatelives/Docker.tmbundle</string>
-	<key>ref</key><string>master</string>
+	<key>ref</key><string>main</string>
 	<key>autoUpdate</key><true/>
 	<key>category</key><string>Build</string>
 			<key>description</key><string>Helpers for Docker.</string>
@@ -46,7 +46,7 @@
 	<key>uuid</key><string>FF4C85FD-F635-42B7-B15D-2CB2241AF54D</string>
 	<key>name</key><string>Rave</string>
 	<key>url</key><string>https://github.com/textmatelives/rave.tmbundle</string>
-	<key>ref</key><string>master</string>
+	<key>ref</key><string>main</string>
 	<key>autoUpdate</key><true/>
 	<key>category</key><string>Build</string>
 			<key>description</key><string>Rave (https://macromates.com/rave/) is a build file generator for the Ninja build system (https://ninja-build.org/).</string>
@@ -73,7 +73,7 @@
 	<key>uuid</key><string>7F43D670-A808-4D6E-BDE7-8CD71C2396EC</string>
 	<key>name</key><string>ANTLR</string>
 	<key>url</key><string>https://github.com/textmatelives/antlr.tmbundle</string>
-	<key>ref</key><string>master</string>
+	<key>ref</key><string>main</string>
 	<key>autoUpdate</key><true/>
 	<key>category</key><string>Languages</string>
 			<key>description</key><string>Support for the ANTLR (http://www.antlr.org/) parser generator tool.</string>
@@ -100,7 +100,7 @@
 	<key>uuid</key><string>344D329E-6B21-11D9-B355-000D93589AF6</string>
 	<key>name</key><string>ASP</string>
 	<key>url</key><string>https://github.com/textmatelives/asp.tmbundle</string>
-	<key>ref</key><string>master</string>
+	<key>ref</key><string>main</string>
 	<key>autoUpdate</key><true/>
 	<key>category</key><string>Languages</string>
 			<key>description</key><string>Language grammar, snippets, and more for ASP.</string>
@@ -109,7 +109,7 @@
 	<key>uuid</key><string>4F07B982-DA8C-49E5-AB47-3C0C79BE562B</string>
 	<key>name</key><string>ASP vb.NET</string>
 	<key>url</key><string>https://github.com/textmatelives/asp.vb.net.tmbundle</string>
-	<key>ref</key><string>master</string>
+	<key>ref</key><string>main</string>
 	<key>autoUpdate</key><true/>
 	<key>category</key><string>Languages</string>
 			<key>description</key><string>Lots of snippets and a language grammar for ASP.NET (http://www.asp.net/)</string>
@@ -118,7 +118,7 @@
 	<key>uuid</key><string>A8A52DF1-BAFB-4071-B738-16CE26F78B0A</string>
 	<key>name</key><string>Bison</string>
 	<key>url</key><string>https://github.com/textmatelives/bison.tmbundle</string>
-	<key>ref</key><string>master</string>
+	<key>ref</key><string>main</string>
 	<key>autoUpdate</key><true/>
 	<key>category</key><string>Languages</string>
 			<key>description</key><string>Support for the Bison parser generator.</string>
@@ -127,7 +127,7 @@
 	<key>uuid</key><string>5A841EC2-B9E2-4E96-AA2F-D49CAC1F0C4A</string>
 	<key>name</key><string>Bulletin Board</string>
 	<key>url</key><string>https://github.com/textmatelives/bulletin-board.tmbundle</string>
-	<key>ref</key><string>master</string>
+	<key>ref</key><string>main</string>
 	<key>autoUpdate</key><true/>
 	<key>category</key><string>Languages</string>
 			<key>description</key><string>Supports one variant of the BBCode markup language (http://www.bbcode.org/).</string>
@@ -136,7 +136,7 @@
 	<key>uuid</key><string>66623882-73FB-11D9-85C6-000D93589AF6</string>
 	<key>name</key><string>C#</string>
 	<key>url</key><string>https://github.com/textmatelives/csharp-tmbundle</string>
-	<key>ref</key><string>master</string>
+	<key>ref</key><string>main</string>
 	<key>autoUpdate</key><true/>
 	<key>category</key><string>Languages</string>
 			<key>description</key><string>Language grammar, snippets, and more for the C# language. Which is intended to be a simple, modern, general-purpose, object-oriented programming language. To be executed through an implementation of the Common Language Runtime (CLR). Such as the Microsoft .NET Initiative (http://msdn.microsoft.com/netframework/), Mono (http://www.mono-project.com/) or dotGNU (http://www.gnu.org/software/dotgnu/).</string>
@@ -145,7 +145,7 @@
 	<key>uuid</key><string>B5EEC818-98AC-486C-B158-966F88511EC0</string>
 	<key>name</key><string>Cap’n Proto</string>
 	<key>url</key><string>https://github.com/textmatelives/capnproto.tmbundle</string>
-	<key>ref</key><string>master</string>
+	<key>ref</key><string>main</string>
 	<key>autoUpdate</key><true/>
 	<key>category</key><string>Languages</string>
 			<key>description</key><string>Data interchange format similar to protobuf</string>
@@ -163,7 +163,7 @@
 	<key>uuid</key><string>A29B280D-8D4C-4416-AC5A-97F50669603A</string>
 	<key>name</key><string>F Sharp</string>
 	<key>url</key><string>https://github.com/textmatelives/f-sharp.tmbundle</string>
-	<key>ref</key><string>master</string>
+	<key>ref</key><string>main</string>
 	<key>autoUpdate</key><true/>
 	<key>category</key><string>Languages</string>
 			<key>description</key><string>Syntax highlighting for F#, a .NET functional programming language.</string>
@@ -172,7 +172,7 @@
 	<key>uuid</key><string>AFB88386-F238-4FB6-B476-A6A7E1491A88</string>
 	<key>name</key><string>Forth</string>
 	<key>url</key><string>https://github.com/textmatelives/forth.tmbundle</string>
-	<key>ref</key><string>master</string>
+	<key>ref</key><string>main</string>
 	<key>autoUpdate</key><true/>
 	<key>category</key><string>Languages</string>
 			<key>description</key><string>A stack-based programming language.</string>
@@ -190,7 +190,7 @@
 	<key>uuid</key><string>191B06AB-47B8-4E72-B0DE-291A35D93B99</string>
 	<key>name</key><string>Gettext</string>
 	<key>url</key><string>https://github.com/textmatelives/gettext.tmbundle</string>
-	<key>ref</key><string>master</string>
+	<key>ref</key><string>main</string>
 	<key>autoUpdate</key><true/>
 	<key>category</key><string>Languages</string>
 			<key>description</key><string>gettext is the GNU Project's toolset for helping programmers and translators to produce multi-lingual messages for software. The toolset can be (and often is) used by java, perl, php, shell and many other languages. This bundle provides syntax highlighting and utilities to help in preparing *.po files, which are text files containing the various messages and their translations</string>
@@ -208,7 +208,7 @@
 	<key>uuid</key><string>344D1644-6B21-11D9-B355-000D93589AF6</string>
 	<key>name</key><string>Graphviz</string>
 	<key>url</key><string>https://github.com/textmatelives/graphviz.tmbundle</string>
-	<key>ref</key><string>master</string>
+	<key>ref</key><string>main</string>
 	<key>autoUpdate</key><true/>
 	<key>category</key><string>Languages</string>
 			<key>description</key><string>Graph visualization software, more info (http://www.graphviz.org/).</string>
@@ -217,7 +217,7 @@
 	<key>uuid</key><string>47889EBB-6E0F-4D16-ADDE-0616D5795636</string>
 	<key>name</key><string>Gri</string>
 	<key>url</key><string>https://github.com/textmatelives/gri.tmbundle</string>
-	<key>ref</key><string>master</string>
+	<key>ref</key><string>main</string>
 	<key>autoUpdate</key><true/>
 	<key>category</key><string>Languages</string>
 			<key>description</key><string>Support for Gri (http://gri.sourceforge.net/), a language for scientific graphics programming.</string>
@@ -235,7 +235,7 @@
 	<key>uuid</key><string>46779A0A-6227-11D9-BFB1-000D93589AF6</string>
 	<key>name</key><string>iCalendar</string>
 	<key>url</key><string>https://github.com/textmatelives/icalendar.tmbundle</string>
-	<key>ref</key><string>master</string>
+	<key>ref</key><string>main</string>
 	<key>autoUpdate</key><true/>
 	<key>category</key><string>Languages</string>
 			<key>description</key><string>Syntax highlight for the iCalendar format (http://tools.ietf.org/html/rfc2445).</string>
@@ -244,7 +244,7 @@
 	<key>uuid</key><string>77B12BEB-8A90-11D9-BAA4-000A9584EC8C</string>
 	<key>name</key><string>Ini</string>
 	<key>url</key><string>https://github.com/textmatelives/ini.tmbundle</string>
-	<key>ref</key><string>master</string>
+	<key>ref</key><string>main</string>
 	<key>autoUpdate</key><true/>
 	<key>category</key><string>Languages</string>
 			<key>description</key><string>Support for Ini(tialization) (http://en.wikipedia.org/wiki/INI_file) / config files (mostly found on MS Windows).</string>
@@ -253,7 +253,7 @@
 	<key>uuid</key><string>0A5DEA4F-3A77-4CA5-9319-C8F885127572</string>
 	<key>name</key><string>Installer</string>
 	<key>url</key><string>https://github.com/textmatelives/installer.tmbundle</string>
-	<key>ref</key><string>master</string>
+	<key>ref</key><string>main</string>
 	<key>autoUpdate</key><true/>
 	<key>category</key><string>Languages</string>
 			<key>description</key><string>Syntax for writing Installer distribution scripts (http://developer.apple.com/releasenotes/DeveloperTools/Installer.html). Combines XML with JavaScript + custom symbol highlighting.</string>
@@ -262,7 +262,7 @@
 	<key>uuid</key><string>7F48FD99-8480-47CC-8C4B-F6AD17ACF122</string>
 	<key>name</key><string>iPhone</string>
 	<key>url</key><string>https://github.com/textmatelives/iphone.tmbundle</string>
-	<key>ref</key><string>master</string>
+	<key>ref</key><string>main</string>
 	<key>autoUpdate</key><true/>
 	<key>category</key><string>Languages</string>
 			<key>description</key><string>Objective-C with added iPhone grammar parsing.</string>
@@ -271,7 +271,7 @@
 	<key>uuid</key><string>44339853-BBEB-44BF-9E69-B70E8E040B4C</string>
 	<key>name</key><string>Java Velocity</string>
 	<key>url</key><string>https://github.com/textmatelives/java-velocity.tmbundle</string>
-	<key>ref</key><string>master</string>
+	<key>ref</key><string>main</string>
 	<key>autoUpdate</key><true/>
 	<key>category</key><string>Languages</string>
 			<key>description</key><string>Support for the Velocity (http://velocity.apache.org/engine/devel/user-guide.html) templating language.</string>
@@ -280,7 +280,7 @@
 	<key>uuid</key><string>D0C00F56-0B8D-4972-B958-A82E93F95581</string>
 	<key>name</key><string>JavaDoc</string>
 	<key>url</key><string>https://github.com/textmatelives/javadoc.tmbundle</string>
-	<key>ref</key><string>master</string>
+	<key>ref</key><string>main</string>
 	<key>autoUpdate</key><true/>
 	<key>category</key><string>Languages</string>
 			<key>description</key><string>Javadoc comment helpers for Java source files.</string>
@@ -289,7 +289,7 @@
 	<key>uuid</key><string>DA18BD22-6C7A-4D77-9100-4511229558D9</string>
 	<key>name</key><string>JavaScript jQuery</string>
 	<key>url</key><string>https://github.com/textmatelives/jquery-tmbundle</string>
-	<key>ref</key><string>master</string>
+	<key>ref</key><string>main</string>
 	<key>autoUpdate</key><true/>
 	<key>category</key><string>Languages</string>
 			<key>description</key><string>Support for the jQuery JavaScript library (http://jquery.com/).</string>
@@ -298,7 +298,7 @@
 	<key>uuid</key><string>6FFB94A1-EB29-4A7B-87B7-7E47035CEB79</string>
 	<key>name</key><string>JavaScript JSDoc</string>
 	<key>url</key><string>https://github.com/textmatelives/javascript-jsdoc.tmbundle</string>
-	<key>ref</key><string>master</string>
+	<key>ref</key><string>main</string>
 	<key>autoUpdate</key><true/>
 	<key>category</key><string>Languages</string>
 			<key>description</key><string>Documentation generator for JavaScript code.</string>
@@ -307,7 +307,7 @@
 	<key>uuid</key><string>1FB3D538-84E1-4002-AA46-5705529A27E1</string>
 	<key>name</key><string>JavaScript Objective-J</string>
 	<key>url</key><string>https://github.com/textmatelives/javascript-objective-j.tmbundle</string>
-	<key>ref</key><string>master</string>
+	<key>ref</key><string>main</string>
 	<key>autoUpdate</key><true/>
 	<key>category</key><string>Languages</string>
 			<key>description</key><string>Cappuccino (http://cappuccino.org/) is an open source framework that makes it easy to build desktop-caliber applications that run in a web browser.</string>
@@ -325,7 +325,7 @@
 	<key>uuid</key><string>536A270F-F121-4291-9DC4-59B0AEC9281A</string>
 	<key>name</key><string>K</string>
 	<key>url</key><string>https://github.com/textmatelives/k.tmbundle</string>
-	<key>ref</key><string>master</string>
+	<key>ref</key><string>main</string>
 	<key>autoUpdate</key><true/>
 	<key>category</key><string>Languages</string>
 			<key>description</key><string>A bundle for the programming language K. For more info, refer to Kx Systems (http://www.kx.com/).</string>
@@ -343,7 +343,7 @@
 	<key>uuid</key><string>C473C122-592E-4943-9CB0-44F02C24F780</string>
 	<key>name</key><string>LDIF</string>
 	<key>url</key><string>https://github.com/textmatelives/LDIF.tmbundle</string>
-	<key>ref</key><string>master</string>
+	<key>ref</key><string>main</string>
 	<key>autoUpdate</key><true/>
 	<key>category</key><string>Languages</string>
 			<key>description</key><string>This bundle supports the LDAP Data Interchange Format and other LDAP related tasks.</string>
@@ -361,7 +361,7 @@
 	<key>uuid</key><string>408054F2-BF56-439E-B52F-5EC62ED0A849</string>
 	<key>name</key><string>Lex/Flex</string>
 	<key>url</key><string>https://github.com/textmatelives/lex-flex.tmbundle</string>
-	<key>ref</key><string>master</string>
+	<key>ref</key><string>main</string>
 	<key>autoUpdate</key><true/>
 	<key>category</key><string>Languages</string>
 			<key>description</key><string>Lex/Flex (http://www.freebsd.org/cgi/man.cgi?query=flex) is a lexical analyzer generator.</string>
@@ -370,7 +370,7 @@
 	<key>uuid</key><string>5D9846C9-EB37-4F56-BD7F-F3A6BF8846A0</string>
 	<key>name</key><string>LilyPond</string>
 	<key>url</key><string>https://github.com/textmatelives/lilypond.tmbundle</string>
-	<key>ref</key><string>master</string>
+	<key>ref</key><string>main</string>
 	<key>autoUpdate</key><true/>
 	<key>category</key><string>Languages</string>
 			<key>description</key><string>Support for the Lilypond (http://lilypond.org/web/) music notation format.</string>
@@ -379,7 +379,7 @@
 	<key>uuid</key><string>E61A99D4-248F-4466-BD29-998E6F4E32B7</string>
 	<key>name</key><string>Limbo</string>
 	<key>url</key><string>https://github.com/textmatelives/limbo.tmbundle</string>
-	<key>ref</key><string>master</string>
+	<key>ref</key><string>main</string>
 	<key>autoUpdate</key><true/>
 	<key>category</key><string>Languages</string>
 			<key>description</key><string>Syntax highlighting for the Limbo programming language used by Inferno.</string>
@@ -388,7 +388,7 @@
 	<key>uuid</key><string>46790904-6227-11D9-BFB1-000D93589AF6</string>
 	<key>name</key><string>Lisp</string>
 	<key>url</key><string>https://github.com/textmatelives/lisp.tmbundle</string>
-	<key>ref</key><string>master</string>
+	<key>ref</key><string>main</string>
 	<key>autoUpdate</key><true/>
 	<key>category</key><string>Languages</string>
 			<key>description</key><string>Support for the Lisp (http://en.wikipedia.org/wiki/Lisp_%28programming_language%29) functional programming language.</string>
@@ -397,7 +397,7 @@
 	<key>uuid</key><string>72FC431C-997D-4CBF-A4F2-66F6638F9CB6</string>
 	<key>name</key><string>Logo</string>
 	<key>url</key><string>https://github.com/textmatelives/logo.tmbundle</string>
-	<key>ref</key><string>master</string>
+	<key>ref</key><string>main</string>
 	<key>autoUpdate</key><true/>
 	<key>category</key><string>Languages</string>
 			<key>description</key><string>Support for Logo (http://en.wikipedia.org/wiki/Logo_programming_language), the educational programming language best known for its turtle drawing mode.</string>
@@ -406,7 +406,7 @@
 	<key>uuid</key><string>C100CC05-6EDB-11D9-8798-000A95DAA580</string>
 	<key>name</key><string>Logtalk</string>
 	<key>url</key><string>https://github.com/textmatelives/logtalk.tmbundle</string>
-	<key>ref</key><string>master</string>
+	<key>ref</key><string>main</string>
 	<key>autoUpdate</key><true/>
 	<key>category</key><string>Languages</string>
 			<key>description</key><string>Logtalk (http://logtalk.org/) is an object-oriented extension to Prolog.</string>
@@ -415,7 +415,7 @@
 	<key>uuid</key><string>E6C0E3CA-DDB8-4491-93DA-5BBC04C95951</string>
 	<key>name</key><string>MacPorts</string>
 	<key>url</key><string>https://github.com/textmatelives/macports.tmbundle</string>
-	<key>ref</key><string>master</string>
+	<key>ref</key><string>main</string>
 	<key>autoUpdate</key><true/>
 	<key>category</key><string>Languages</string>
 			<key>description</key><string>Syntax highlight and a template for the portfile format used by MacPorts (http://www.macports.org/).</string>
@@ -433,7 +433,7 @@
 	<key>uuid</key><string>A9CF0E77-E848-417C-90F4-77E1231FF1B9</string>
 	<key>name</key><string>Markdown (GitHub)</string>
 	<key>url</key><string>https://github.com/textmatelives/GitHub-Markdown.tmbundle</string>
-	<key>ref</key><string>master</string>
+	<key>ref</key><string>main</string>
 	<key>autoUpdate</key><true/>
 	<key>category</key><string>Languages</string>
 			<key>description</key><string>GFM syntax highlighting and preview.</string>
@@ -478,7 +478,7 @@
 	<key>uuid</key><string>64C4222F-7054-4A26-B91E-A82F53166142</string>
 	<key>name</key><string>Mediawiki</string>
 	<key>url</key><string>https://github.com/textmatelives/mediawiki.tmbundle</string>
-	<key>ref</key><string>master</string>
+	<key>ref</key><string>main</string>
 	<key>autoUpdate</key><true/>
 	<key>category</key><string>Languages</string>
 			<key>description</key><string>MediaWiki (http://www.mediawiki.org/wiki/MediaWiki) (inc. Wikipedia) support for TextMate.</string>
@@ -496,7 +496,7 @@
 	<key>uuid</key><string>005ECD5C-8762-4E90-8D8F-C778C91FFB66</string>
 	<key>name</key><string>Movable Type</string>
 	<key>url</key><string>https://github.com/textmatelives/movable-type.tmbundle</string>
-	<key>ref</key><string>master</string>
+	<key>ref</key><string>main</string>
 	<key>autoUpdate</key><true/>
 	<key>category</key><string>Languages</string>
 			<key>description</key><string>Support for creating templates for the Movable Type (http://www.movabletype.org/) content management system.</string>
@@ -505,7 +505,7 @@
 	<key>uuid</key><string>5B1D8959-F6BB-4F99-9E28-C97BFF447DF6</string>
 	<key>name</key><string>Mx</string>
 	<key>url</key><string>https://github.com/textmatelives/mx.tmbundle</string>
-	<key>ref</key><string>master</string>
+	<key>ref</key><string>main</string>
 	<key>autoUpdate</key><true/>
 	<key>category</key><string>Languages</string>
 			<key>description</key><string>A matrix algebra and optimizer language.</string>
@@ -523,7 +523,7 @@
 	<key>uuid</key><string>8E974139-4838-4E8E-B70E-0A552EB9760E</string>
 	<key>name</key><string>OpenGL</string>
 	<key>url</key><string>https://github.com/textmatelives/opengl.tmbundle</string>
-	<key>ref</key><string>master</string>
+	<key>ref</key><string>main</string>
 	<key>autoUpdate</key><true/>
 	<key>category</key><string>Languages</string>
 			<key>description</key><string>Syntax highlight for functions found in the OpenGL (http://opengl.org/) 3D graphics library.</string>
@@ -532,7 +532,7 @@
 	<key>uuid</key><string>2CD058CC-E5E2-41BC-8FF8-0C2BFC043F3E</string>
 	<key>name</key><string>OpenMx</string>
 	<key>url</key><string>https://github.com/textmatelives/OpenMx.tmbundle</string>
-	<key>ref</key><string>master</string>
+	<key>ref</key><string>main</string>
 	<key>autoUpdate</key><true/>
 	<key>category</key><string>Languages</string>
 			<key>description</key><string>Structural equation modeling and matrix algebra in the [OpenMx](http://openmx.psyc.virginia.edu) and [umx](http://tbates.github.io) [R](http://cran.r-project.org) packages</string>
@@ -541,7 +541,7 @@
 	<key>uuid</key><string>3086DFC6-6DEA-461E-9137-257B18408D56</string>
 	<key>name</key><string>Parrot</string>
 	<key>url</key><string>https://github.com/textmatelives/parrot.tmbundle</string>
-	<key>ref</key><string>master</string>
+	<key>ref</key><string>main</string>
 	<key>autoUpdate</key><true/>
 	<key>category</key><string>Languages</string>
 			<key>description</key><string>This bundle contains language grammar and snippets for PIR programming language (http://parrotcode.org/) from parrot VM.</string>
@@ -550,7 +550,7 @@
 	<key>uuid</key><string>46799436-6227-11D9-BFB1-000D93589AF6</string>
 	<key>name</key><string>Pascal</string>
 	<key>url</key><string>https://github.com/textmatelives/pascal.tmbundle</string>
-	<key>ref</key><string>master</string>
+	<key>ref</key><string>main</string>
 	<key>autoUpdate</key><true/>
 	<key>category</key><string>Languages</string>
 			<key>description</key><string>Support for the Pascal (http://en.wikipedia.org/wiki/Pascal_(programming_language)) programming language.</string>
@@ -568,7 +568,7 @@
 	<key>uuid</key><string>5A67ADDC-283A-4E0F-AA36-29E4E95B4A26</string>
 	<key>name</key><string>Perl HTML::Template</string>
 	<key>url</key><string>https://github.com/textmatelives/perl-html-template.tmbundle</string>
-	<key>ref</key><string>master</string>
+	<key>ref</key><string>main</string>
 	<key>autoUpdate</key><true/>
 	<key>category</key><string>Languages</string>
 			<key>description</key><string>HTML::Template (http://html-template.sourceforge.net/) is a template processing system for Perl.</string>
@@ -577,7 +577,7 @@
 	<key>uuid</key><string>73C53C31-8AFA-4369-A92F-E5D6904EF628</string>
 	<key>name</key><string>Postscript</string>
 	<key>url</key><string>https://github.com/textmatelives/postscript.tmbundle</string>
-	<key>ref</key><string>master</string>
+	<key>ref</key><string>main</string>
 	<key>autoUpdate</key><true/>
 	<key>category</key><string>Languages</string>
 			<key>description</key><string>Support for the Postscript (http://www.adobe.com/products/postscript/) langauge, generally associated with printers.</string>
@@ -613,7 +613,7 @@
 	<key>uuid</key><string>230EB053-6E5D-11D9-BE5A-0011242E4184</string>
 	<key>name</key><string>Quake</string>
 	<key>url</key><string>https://github.com/textmatelives/quake.tmbundle</string>
-	<key>ref</key><string>master</string>
+	<key>ref</key><string>main</string>
 	<key>autoUpdate</key><true/>
 	<key>category</key><string>Languages</string>
 			<key>description</key><string>Support for editing your Quake configuration files (http://wiki.quakesrc.org/index.php/Quake%20File%20Formats).</string>
@@ -631,7 +631,7 @@
 	<key>uuid</key><string>CE1CE629-A9D6-4918-94C9-824D527276FD</string>
 	<key>name</key><string>Ragel</string>
 	<key>url</key><string>https://github.com/textmatelives/ragel.tmbundle</string>
-	<key>ref</key><string>master</string>
+	<key>ref</key><string>main</string>
 	<key>autoUpdate</key><true/>
 	<key>category</key><string>Languages</string>
 			<key>description</key><string>Ragel (http://www.cs.queensu.ca/~thurston/ragel/) compiles finite state machines from regular languages into executable C, C++, Objective-C, or D code.</string>
@@ -640,7 +640,7 @@
 	<key>uuid</key><string>B5254936-065A-4E65-8F58-3540179AC959</string>
 	<key>name</key><string>Rez</string>
 	<key>url</key><string>https://github.com/textmatelives/rez.tmbundle</string>
-	<key>ref</key><string>master</string>
+	<key>ref</key><string>main</string>
 	<key>autoUpdate</key><true/>
 	<key>category</key><string>Languages</string>
 			<key>description</key><string>A resource description file (http://kevin.sb.org/articles/2006/06/06/the-rez-file-format) is Mac-specific and used to compile the resource fork of a file using the rez shell command.</string>
@@ -649,7 +649,7 @@
 	<key>uuid</key><string>4618480A-F4C3-40FE-8719-DE54CBDFB92A</string>
 	<key>name</key><string>Ruby Haml</string>
 	<key>url</key><string>https://github.com/textmatelives/ruby-haml.tmbundle</string>
-	<key>ref</key><string>master</string>
+	<key>ref</key><string>main</string>
 	<key>autoUpdate</key><true/>
 	<key>category</key><string>Languages</string>
 			<key>description</key><string>Template engine for Ruby on Rails.</string>
@@ -667,7 +667,7 @@
 	<key>uuid</key><string>176253C8-5D97-4C20-AA34-3BE8BC73FBC9</string>
 	<key>name</key><string>Ruby Sass</string>
 	<key>url</key><string>https://github.com/textmatelives/ruby-sass.tmbundle</string>
-	<key>ref</key><string>master</string>
+	<key>ref</key><string>main</string>
 	<key>autoUpdate</key><true/>
 	<key>category</key><string>Languages</string>
 			<key>description</key><string>Template language for easily creating CSS; implemented in ruby.</string>
@@ -676,7 +676,7 @@
 	<key>uuid</key><string>8EDBE2CA-575A-42BC-9F36-BD4C99B4DE56</string>
 	<key>name</key><string>Ruby Shoulda</string>
 	<key>url</key><string>https://github.com/textmatelives/ruby-shoulda.tmbundle</string>
-	<key>ref</key><string>master</string>
+	<key>ref</key><string>main</string>
 	<key>autoUpdate</key><true/>
 	<key>category</key><string>Languages</string>
 			<key>description</key><string>Support for the Shoulda (http://thoughtbot.com/projects/shoulda) testing framework.</string>
@@ -685,7 +685,7 @@
 	<key>uuid</key><string>A24283A1-6C91-4CDB-80C5-DC606ED62F04</string>
 	<key>name</key><string>Ruby Slim</string>
 	<key>url</key><string>https://github.com/textmatelives/ruby-slim.tmbundle</string>
-	<key>ref</key><string>master</string>
+	<key>ref</key><string>main</string>
 	<key>autoUpdate</key><true/>
 	<key>category</key><string>Languages</string>
 			<key>description</key><string>A lightweight templating engine for ruby, more info (http://slim-lang.com).</string>
@@ -721,7 +721,7 @@
 	<key>uuid</key><string>C397B72C-7519-44CD-8533-7AB7F701C4E4</string>
 	<key>name</key><string>Scilab</string>
 	<key>url</key><string>https://github.com/textmatelives/scilab.tmbundle</string>
-	<key>ref</key><string>master</string>
+	<key>ref</key><string>main</string>
 	<key>autoUpdate</key><true/>
 	<key>category</key><string>Languages</string>
 			<key>description</key><string>Scilab (http://www.scilab.org/) is a numerical computational package developed by INRIA and ENPC in France. It is similar in functionality to MATLAB and is available to download at no cost.</string>
@@ -730,7 +730,7 @@
 	<key>uuid</key><string>BCEB5483-E029-479F-95AC-D6AADF98138F</string>
 	<key>name</key><string>SCSS</string>
 	<key>url</key><string>https://github.com/textmatelives/SCSS.tmbundle</string>
-	<key>ref</key><string>master</string>
+	<key>ref</key><string>main</string>
 	<key>autoUpdate</key><true/>
 	<key>category</key><string>Languages</string>
 			<key>description</key><string>Syntactically awesome stylesheets (http://sass-lang.com) are translated to well-formatted, standard CSS using the command line tool or a web-framework plugin. This bundle has syntax highlight, lots of snippets, validation, and more.</string>
@@ -739,7 +739,7 @@
 	<key>uuid</key><string>7471537C-4EC6-4CCF-B93A-F087986CA465</string>
 	<key>name</key><string>Smalltalk</string>
 	<key>url</key><string>https://github.com/textmatelives/smalltalk-tmbundle</string>
-	<key>ref</key><string>master</string>
+	<key>ref</key><string>main</string>
 	<key>autoUpdate</key><true/>
 	<key>category</key><string>Languages</string>
 			<key>description</key><string>An object-oriented, dynamically typed, reflective programming language.</string>
@@ -748,7 +748,7 @@
 	<key>uuid</key><string>7A3C2CE9-C65D-4116-92B7-F10D684B1ED6</string>
 	<key>name</key><string>SSH Config</string>
 	<key>url</key><string>https://github.com/textmatelives/ssh-config.tmbundle</string>
-	<key>ref</key><string>master</string>
+	<key>ref</key><string>main</string>
 	<key>autoUpdate</key><true/>
 	<key>category</key><string>Languages</string>
 			<key>description</key><string>Syntax highlight for ssh (http://www.openssh.com/) configuration files.</string>
@@ -766,7 +766,7 @@
 	<key>uuid</key><string>8C563B34-BE0B-11D9-B4D9-000393A143CC</string>
 	<key>name</key><string>SWIG</string>
 	<key>url</key><string>https://github.com/textmatelives/swig.tmbundle</string>
-	<key>ref</key><string>master</string>
+	<key>ref</key><string>main</string>
 	<key>autoUpdate</key><true/>
 	<key>category</key><string>Languages</string>
 			<key>description</key><string>SWIG (http://www.swig.org/) is a software development tool that connects programs written in C and C++ with a variety of high-level programming languages.</string>
@@ -775,7 +775,7 @@
 	<key>uuid</key><string>D587784E-13B0-4090-BF67-42717CC5F89F</string>
 	<key>name</key><string>Tabular</string>
 	<key>url</key><string>https://github.com/textmatelives/tabular.tmbundle</string>
-	<key>ref</key><string>master</string>
+	<key>ref</key><string>main</string>
 	<key>autoUpdate</key><true/>
 	<key>category</key><string>Languages</string>
 			<key>description</key><string>Support for comma and tab separated values (CSV (http://en.wikipedia.org/wiki/Comma-separated_values) and TSV).</string>
@@ -793,7 +793,7 @@
 	<key>uuid</key><string>49882962-7CB7-11D9-875B-000A95E13C98</string>
 	<key>name</key><string>Tcl</string>
 	<key>url</key><string>https://github.com/textmatelives/tcl.tmbundle</string>
-	<key>ref</key><string>master</string>
+	<key>ref</key><string>main</string>
 	<key>autoUpdate</key><true/>
 	<key>category</key><string>Languages</string>
 			<key>description</key><string>Tcl (http://www.tcl.tk/) (Tool Command Language) is a very powerful but easy to learn dynamic programming language, suitable for a very wide range of uses. It is often used to write GUI frontends for UNIX stuff.</string>
@@ -802,7 +802,7 @@
 	<key>uuid</key><string>19FB3BCA-1F8A-432D-B201-DE249A121059</string>
 	<key>name</key><string>Terraform</string>
 	<key>url</key><string>https://github.com/textmatelives/Terraform.tmbundle</string>
-	<key>ref</key><string>master</string>
+	<key>ref</key><string>main</string>
 	<key>autoUpdate</key><true/>
 	<key>category</key><string>Languages</string>
 			<key>description</key><string>Terraform syntax highlighting and snippets and such</string>
@@ -820,7 +820,7 @@
 	<key>uuid</key><string>4A6C024E-8B12-4119-B7FF-73B10864C7F7</string>
 	<key>name</key><string>Treetop</string>
 	<key>url</key><string>https://github.com/textmatelives/treetop.tmbundle</string>
-	<key>ref</key><string>master</string>
+	<key>ref</key><string>main</string>
 	<key>autoUpdate</key><true/>
 	<key>category</key><string>Languages</string>
 			<key>description</key><string>A language for describing languages</string>
@@ -838,7 +838,7 @@
 	<key>uuid</key><string>1A78F224-6213-41FB-A7AB-8C17F6BC196D</string>
 	<key>name</key><string>Vectorscript</string>
 	<key>url</key><string>https://github.com/textmatelives/vectorscript.tmbundle</string>
-	<key>ref</key><string>master</string>
+	<key>ref</key><string>main</string>
 	<key>autoUpdate</key><true/>
 	<key>category</key><string>Languages</string>
 			<key>description</key><string>The scripting language used by the VectorWorks (http://www.nemetschek.net/support/custom/vscript/index.php) CAD software.</string>
@@ -847,7 +847,7 @@
 	<key>uuid</key><string>49BC43A3-4562-4B87-8B43-38ABDA4C8E6B</string>
 	<key>name</key><string>Verilog</string>
 	<key>url</key><string>https://github.com/textmatelives/verilog.tmbundle</string>
-	<key>ref</key><string>master</string>
+	<key>ref</key><string>main</string>
 	<key>autoUpdate</key><true/>
 	<key>category</key><string>Languages</string>
 			<key>description</key><string>Gives support for Verilog including syntax highlighting, code folding and symbols.</string>
@@ -856,7 +856,7 @@
 	<key>uuid</key><string>F5351E61-488E-44A5-BF0B-02FED526B641</string>
 	<key>name</key><string>VHDL</string>
 	<key>url</key><string>https://github.com/textmatelives/vhdl.tmbundle</string>
-	<key>ref</key><string>master</string>
+	<key>ref</key><string>main</string>
 	<key>autoUpdate</key><true/>
 	<key>category</key><string>Languages</string>
 			<key>description</key><string>Hardware description language used in electronic design automation.</string>
@@ -865,7 +865,7 @@
 	<key>uuid</key><string>7CF5FE7E-92F6-4E4E-A4CA-6C876E319910</string>
 	<key>name</key><string>XQuery</string>
 	<key>url</key><string>https://github.com/textmatelives/xquery.tmbundle</string>
-	<key>ref</key><string>master</string>
+	<key>ref</key><string>main</string>
 	<key>autoUpdate</key><true/>
 	<key>category</key><string>Languages</string>
 			<key>description</key><string>XQuery (http://www.w3.org/TR/xquery/) is a language for querying collections of XML data.</string>
@@ -883,7 +883,7 @@
 	<key>uuid</key><string>4F9ED080-B8B8-11D9-AE51-000393A143CC</string>
 	<key>name</key><string>ODCompletion</string>
 	<key>url</key><string>https://github.com/textmatelives/odcompletion.tmbundle</string>
-	<key>ref</key><string>master</string>
+	<key>ref</key><string>main</string>
 	<key>autoUpdate</key><true/>
 	<key>category</key><string>Other</string>
 			<key>description</key><string>Code completion snippets for Objective-C (http://developer.apple.com/documentation/Cocoa/Conceptual/ObjectiveC/index.html), inspired by the Objective Development code completion dictionary (http://www.obdev.at/products/completion-dictionary/index.html) for Xcode.</string>
@@ -892,7 +892,7 @@
 	<key>uuid</key><string>13FEBB9E-8300-11D9-B216-000D9332809C</string>
 	<key>name</key><string>Outlines</string>
 	<key>url</key><string>https://github.com/textmatelives/outlines.tmbundle</string>
-	<key>ref</key><string>master</string>
+	<key>ref</key><string>main</string>
 	<key>autoUpdate</key><true/>
 	<key>category</key><string>Other</string>
 			<key>description</key><string>Various commands for converting textual outlines (defined via indent) to other formats, such as HTML and LaTeX.</string>
@@ -928,7 +928,7 @@
 	<key>uuid</key><string>95761F74-1A3D-4B51-BA03-41537C38C792</string>
 	<key>name</key><string>FileMerge</string>
 	<key>url</key><string>https://github.com/textmatelives/filemerge.tmbundle</string>
-	<key>ref</key><string>master</string>
+	<key>ref</key><string>main</string>
 	<key>autoUpdate</key><true/>
 	<key>category</key><string>SCM</string>
 			<key>description</key><string>Subversion diff commands that use FileMerge (http://developer.apple.com/documentation/DeveloperTools/Conceptual/XcodeUserGuide/Contents/Resources/en.lproj/04_03_SCMManagingFiles/chapter_28_section_8.html#//apple_ref/doc/uid/TP40002687-CJBHDBJD).</string>
@@ -937,7 +937,7 @@
 	<key>uuid</key><string>9ADE27C6-4432-449C-9D4C-B5FEC8D33ACA</string>
 	<key>name</key><string>CxxTest</string>
 	<key>url</key><string>https://github.com/textmatelives/cxxtest.tmbundle</string>
-	<key>ref</key><string>master</string>
+	<key>ref</key><string>main</string>
 	<key>autoUpdate</key><true/>
 	<key>category</key><string>Testing</string>
 			<key>description</key><string>C++ unit testing framework (manual (http://cxxtest.sourceforge.net/guide.html))</string>
@@ -946,7 +946,7 @@
 	<key>uuid</key><string>64D20B78-A6BB-4120-B794-00D909680D8D</string>
 	<key>name</key><string>Objective-C Unit Testing</string>
 	<key>url</key><string>https://github.com/textmatelives/objective-c-unit-testing.tmbundle</string>
-	<key>ref</key><string>master</string>
+	<key>ref</key><string>main</string>
 	<key>autoUpdate</key><true/>
 	<key>category</key><string>Testing</string>
 			<key>description</key><string>For running Objextive-C unit tests using the unit testing framework included with Xcode.</string>
@@ -964,7 +964,7 @@
 	<key>uuid</key><string>C09480C2-10EC-4076-BC5D-281F96917C6B</string>
 	<key>name</key><string>LaTeX Font Settings</string>
 	<key>url</key><string>https://github.com/textmatelives/LaTeX-Font-Settings.tmbundle</string>
-	<key>ref</key><string>master</string>
+	<key>ref</key><string>main</string>
 	<key>autoUpdate</key><true/>
 	<key>category</key><string>Themes</string>
 			<key>description</key><string>Increases the visual font size of section declarations.</string>
@@ -973,7 +973,7 @@
 	<key>uuid</key><string>BC5DE172-1E1A-457C-8807-0B958DDE5B2D</string>
 	<key>name</key><string>Made of Code</string>
 	<key>url</key><string>https://github.com/textmatelives/made-of-code-tmbundle</string>
-	<key>ref</key><string>master</string>
+	<key>ref</key><string>main</string>
 	<key>autoUpdate</key><true/>
 	<key>category</key><string>Themes</string>
 			<key>description</key><string>Vibrant colors on a deep blue background.</string>
@@ -982,7 +982,7 @@
 	<key>uuid</key><string>91ABC535-7C8F-46B0-92E0-570A73450604</string>
 	<key>name</key><string>Markdown (GitHub) Font Settings</string>
 	<key>url</key><string>https://github.com/textmatelives/GitHub-Markdown-Font-Settings.tmbundle</string>
-	<key>ref</key><string>master</string>
+	<key>ref</key><string>main</string>
 	<key>autoUpdate</key><true/>
 	<key>category</key><string>Themes</string>
 			<key>description</key><string>GFM body, heading and raw font styling.</string>
@@ -991,7 +991,7 @@
 	<key>uuid</key><string>F019CDBF-4AFC-4CD0-8EFF-A78FAD2FCB5E</string>
 	<key>name</key><string>Monokai</string>
 	<key>url</key><string>https://github.com/textmatelives/monokai.tmbundle</string>
-	<key>ref</key><string>master</string>
+	<key>ref</key><string>main</string>
 	<key>autoUpdate</key><true/>
 	<key>category</key><string>Themes</string>
 			<key>description</key><string>A colorful, friendly theme; originally by Wimer Hazenberg (http://www.monokai.nl/).</string>

--- a/Applications/TextMate/resources/DefaultBundles.plist
+++ b/Applications/TextMate/resources/DefaultBundles.plist
@@ -9,47 +9,47 @@
 		<dict>
 			<key>uuid</key><string>D4FB34BC-80F3-11D9-9D53-00039398C572</string>
 			<key>name</key><string>Apache</string>
-			<key>url</key><string>https://github.com/dayglojesus/apache.tmbundle</string>
-			<key>ref</key><string>remove-legacy-ruby</string>
+			<key>url</key><string>https://github.com/textmatelives/apache.tmbundle</string>
+			<key>ref</key><string>main</string>
 			<key>autoUpdate</key><true/>
 			<key>category</key><string>Languages</string>
 		</dict>
 		<dict>
 			<key>uuid</key><string>679EFB46-5368-47E5-85BA-DEF72709A471</string>
 			<key>name</key><string>Bundle Development</string>
-			<key>url</key><string>https://github.com/dayglojesus/bundle-development.tmbundle</string>
-			<key>ref</key><string>remove-legacy-ruby</string>
+			<key>url</key><string>https://github.com/textmatelives/bundle-development.tmbundle</string>
+			<key>ref</key><string>main</string>
 			<key>autoUpdate</key><true/>
 			<key>category</key><string>Build</string>
 		</dict>
 		<dict>
 			<key>uuid</key><string>4675A940-6227-11D9-BFB1-000D93589AF6</string>
 			<key>name</key><string>C</string>
-			<key>url</key><string>https://github.com/dayglojesus/c.tmbundle</string>
-			<key>ref</key><string>remove-legacy-ruby</string>
+			<key>url</key><string>https://github.com/textmatelives/c.tmbundle</string>
+			<key>ref</key><string>main</string>
 			<key>autoUpdate</key><true/>
 			<key>category</key><string>Languages</string>
 		</dict>
 		<dict>
 			<key>uuid</key><string>4675F24E-6227-11D9-BFB1-000D93589AF6</string>
 			<key>name</key><string>CSS</string>
-			<key>url</key><string>https://github.com/dayglojesus/css.tmbundle</string>
-			<key>ref</key><string>remove-legacy-ruby</string>
+			<key>url</key><string>https://github.com/textmatelives/css.tmbundle</string>
+			<key>ref</key><string>main</string>
 			<key>autoUpdate</key><true/>
 			<key>category</key><string>Languages</string>
 		</dict>
 		<dict>
 			<key>uuid</key><string>62FB4173-A31D-41D6-8201-16C7866F567E</string>
 			<key>name</key><string>CVS</string>
-			<key>url</key><string>https://github.com/dayglojesus/cvs.tmbundle</string>
-			<key>ref</key><string>remove-legacy-ruby</string>
+			<key>url</key><string>https://github.com/textmatelives/cvs.tmbundle</string>
+			<key>ref</key><string>main</string>
 			<key>autoUpdate</key><true/>
 			<key>category</key><string>SCM</string>
 		</dict>
 		<dict>
 			<key>uuid</key><string>A46E4382-F1AC-405B-8F22-65FF470F34D7</string>
 			<key>name</key><string>CoffeeScript</string>
-			<key>url</key><string>https://github.com/dayglojesus/coffee-script.tmbundle</string>
+			<key>url</key><string>https://github.com/textmatelives/coffee-script.tmbundle</string>
 			<key>ref</key><string>master</string>
 			<key>autoUpdate</key><true/>
 			<key>category</key><string>Languages</string>
@@ -57,7 +57,7 @@
 		<dict>
 			<key>uuid</key><string>7A8214CC-4D64-492C-91A5-F86C666C26B8</string>
 			<key>name</key><string>Cron</string>
-			<key>url</key><string>https://github.com/dayglojesus/cron.tmbundle</string>
+			<key>url</key><string>https://github.com/textmatelives/cron.tmbundle</string>
 			<key>ref</key><string>master</string>
 			<key>autoUpdate</key><true/>
 			<key>category</key><string>Languages</string>
@@ -65,7 +65,7 @@
 		<dict>
 			<key>uuid</key><string>C2D2BFF9-708D-11D9-BD09-0011242E4184</string>
 			<key>name</key><string>Diff</string>
-			<key>url</key><string>https://github.com/dayglojesus/diff.tmbundle</string>
+			<key>url</key><string>https://github.com/textmatelives/diff.tmbundle</string>
 			<key>ref</key><string>master</string>
 			<key>autoUpdate</key><true/>
 			<key>category</key><string>Languages</string>
@@ -73,7 +73,7 @@
 		<dict>
 			<key>uuid</key><string>065A8821-DD83-4753-90E3-AA70EC12E150</string>
 			<key>name</key><string>Erlang</string>
-			<key>url</key><string>https://github.com/dayglojesus/erlang.tmbundle</string>
+			<key>url</key><string>https://github.com/textmatelives/erlang.tmbundle</string>
 			<key>ref</key><string>master</string>
 			<key>autoUpdate</key><true/>
 			<key>category</key><string>Languages</string>
@@ -81,63 +81,63 @@
 		<dict>
 			<key>uuid</key><string>EADD4718-EE11-4ABF-A7E6-13351FB3799D</string>
 			<key>name</key><string>Git</string>
-			<key>url</key><string>https://github.com/dayglojesus/git.tmbundle</string>
-			<key>ref</key><string>remove-legacy-ruby</string>
+			<key>url</key><string>https://github.com/textmatelives/git.tmbundle</string>
+			<key>ref</key><string>main</string>
 			<key>autoUpdate</key><true/>
 			<key>category</key><string>SCM</string>
 		</dict>
 		<dict>
 			<key>uuid</key><string>D9D34536-A9FC-4DC2-8AF4-30D1ACC4B5F4</string>
 			<key>name</key><string>Groovy</string>
-			<key>url</key><string>https://github.com/dayglojesus/groovy.tmbundle</string>
-			<key>ref</key><string>remove-legacy-ruby</string>
+			<key>url</key><string>https://github.com/textmatelives/groovy.tmbundle</string>
+			<key>ref</key><string>main</string>
 			<key>autoUpdate</key><true/>
 			<key>category</key><string>Languages</string>
 		</dict>
 		<dict>
 			<key>uuid</key><string>4676FC6D-6227-11D9-BFB1-000D93589AF6</string>
 			<key>name</key><string>HTML</string>
-			<key>url</key><string>https://github.com/dayglojesus/html.tmbundle</string>
-			<key>ref</key><string>remove-legacy-ruby</string>
+			<key>url</key><string>https://github.com/textmatelives/html.tmbundle</string>
+			<key>ref</key><string>main</string>
 			<key>autoUpdate</key><true/>
 			<key>category</key><string>Languages</string>
 		</dict>
 		<dict>
 			<key>uuid</key><string>7592B521-FC5E-4D69-A6DD-5A0DD7529CB4</string>
 			<key>name</key><string>Hyperlink Helper</string>
-			<key>url</key><string>https://github.com/dayglojesus/hyperlink-helper.tmbundle</string>
-			<key>ref</key><string>remove-legacy-ruby</string>
+			<key>url</key><string>https://github.com/textmatelives/hyperlink-helper.tmbundle</string>
+			<key>ref</key><string>main</string>
 			<key>autoUpdate</key><true/>
 			<key>category</key><string>Other</string>
 		</dict>
 		<dict>
 			<key>uuid</key><string>8BB0DBAF-E65C-4E14-A6A7-467D4AA535E0</string>
 			<key>name</key><string>JSON</string>
-			<key>url</key><string>https://github.com/dayglojesus/json.tmbundle</string>
-			<key>ref</key><string>remove-legacy-ruby</string>
+			<key>url</key><string>https://github.com/textmatelives/json.tmbundle</string>
+			<key>ref</key><string>main</string>
 			<key>autoUpdate</key><true/>
 			<key>category</key><string>Languages</string>
 		</dict>
 		<dict>
 			<key>uuid</key><string>4677FEB2-6227-11D9-BFB1-000D93589AF6</string>
 			<key>name</key><string>Java</string>
-			<key>url</key><string>https://github.com/dayglojesus/java.tmbundle</string>
-			<key>ref</key><string>remove-legacy-ruby</string>
+			<key>url</key><string>https://github.com/textmatelives/java.tmbundle</string>
+			<key>ref</key><string>main</string>
 			<key>autoUpdate</key><true/>
 			<key>category</key><string>Languages</string>
 		</dict>
 		<dict>
 			<key>uuid</key><string>AAB4FD74-73F9-11D9-B89A-000D93589AF6</string>
 			<key>name</key><string>JavaScript</string>
-			<key>url</key><string>https://github.com/dayglojesus/javascript.tmbundle</string>
-			<key>ref</key><string>remove-legacy-ruby</string>
+			<key>url</key><string>https://github.com/textmatelives/javascript.tmbundle</string>
+			<key>ref</key><string>main</string>
 			<key>autoUpdate</key><true/>
 			<key>category</key><string>Languages</string>
 		</dict>
 		<dict>
 			<key>uuid</key><string>5217EA86-3153-4568-B5FD-05917BCE46B3</string>
 			<key>name</key><string>Lua</string>
-			<key>url</key><string>https://github.com/dayglojesus/lua.tmbundle</string>
+			<key>url</key><string>https://github.com/textmatelives/lua.tmbundle</string>
 			<key>ref</key><string>master</string>
 			<key>autoUpdate</key><true/>
 			<key>category</key><string>Languages</string>
@@ -145,47 +145,47 @@
 		<dict>
 			<key>uuid</key><string>385A8908-0733-408E-AFA5-9576D2E3A16B</string>
 			<key>name</key><string>Mail</string>
-			<key>url</key><string>https://github.com/dayglojesus/mail.tmbundle</string>
-			<key>ref</key><string>remove-legacy-ruby</string>
+			<key>url</key><string>https://github.com/textmatelives/mail.tmbundle</string>
+			<key>ref</key><string>main</string>
 			<key>autoUpdate</key><true/>
 			<key>category</key><string>Other</string>
 		</dict>
 		<dict>
 			<key>uuid</key><string>4679297D-6227-11D9-BFB1-000D93589AF6</string>
 			<key>name</key><string>Make</string>
-			<key>url</key><string>https://github.com/dayglojesus/make.tmbundle</string>
-			<key>ref</key><string>remove-legacy-ruby</string>
+			<key>url</key><string>https://github.com/textmatelives/make.tmbundle</string>
+			<key>ref</key><string>main</string>
 			<key>autoUpdate</key><true/>
 			<key>category</key><string>Build</string>
 		</dict>
 		<dict>
 			<key>uuid</key><string>D99E8C0C-792F-11D9-A212-000D93B3A10E</string>
 			<key>name</key><string>Markdown</string>
-			<key>url</key><string>https://github.com/dayglojesus/markdown.tmbundle</string>
-			<key>ref</key><string>remove-legacy-ruby</string>
+			<key>url</key><string>https://github.com/textmatelives/markdown.tmbundle</string>
+			<key>ref</key><string>main</string>
 			<key>autoUpdate</key><true/>
 			<key>category</key><string>Languages</string>
 		</dict>
 		<dict>
 			<key>uuid</key><string>8A9DDCA2-77E8-11D9-B5A8-000D93589AF6</string>
 			<key>name</key><string>Math</string>
-			<key>url</key><string>https://github.com/dayglojesus/math.tmbundle</string>
-			<key>ref</key><string>remove-legacy-ruby</string>
+			<key>url</key><string>https://github.com/textmatelives/math.tmbundle</string>
+			<key>ref</key><string>main</string>
 			<key>autoUpdate</key><true/>
 			<key>category</key><string>Other</string>
 		</dict>
 		<dict>
 			<key>uuid</key><string>162DCB4D-4227-11DA-A523-000D93C89990</string>
 			<key>name</key><string>Mercurial</string>
-			<key>url</key><string>https://github.com/dayglojesus/mercurial.tmbundle</string>
-			<key>ref</key><string>remove-legacy-ruby</string>
+			<key>url</key><string>https://github.com/textmatelives/mercurial.tmbundle</string>
+			<key>ref</key><string>main</string>
 			<key>autoUpdate</key><true/>
 			<key>category</key><string>SCM</string>
 		</dict>
 		<dict>
 			<key>uuid</key><string>90AA78D6-178B-4B6A-AC19-3E5945E2AD82</string>
 			<key>name</key><string>Nix</string>
-			<key>url</key><string>https://github.com/dayglojesus/nix.tmbundle</string>
+			<key>url</key><string>https://github.com/textmatelives/nix.tmbundle</string>
 			<key>ref</key><string>main</string>
 			<key>autoUpdate</key><true/>
 			<key>category</key><string>Languages</string>
@@ -193,23 +193,23 @@
 		<dict>
 			<key>uuid</key><string>4679484F-6227-11D9-BFB1-000D93589AF6</string>
 			<key>name</key><string>Objective-C</string>
-			<key>url</key><string>https://github.com/dayglojesus/objective-c.tmbundle</string>
-			<key>ref</key><string>remove-legacy-ruby</string>
+			<key>url</key><string>https://github.com/textmatelives/objective-c.tmbundle</string>
+			<key>ref</key><string>main</string>
 			<key>autoUpdate</key><true/>
 			<key>category</key><string>Languages</string>
 		</dict>
 		<dict>
 			<key>uuid</key><string>467A1966-6227-11D9-BFB1-000D93589AF6</string>
 			<key>name</key><string>PHP</string>
-			<key>url</key><string>https://github.com/dayglojesus/php.tmbundle</string>
-			<key>ref</key><string>remove-legacy-ruby</string>
+			<key>url</key><string>https://github.com/textmatelives/php.tmbundle</string>
+			<key>ref</key><string>main</string>
 			<key>autoUpdate</key><true/>
 			<key>category</key><string>Languages</string>
 		</dict>
 		<dict>
 			<key>uuid</key><string>4679B572-6227-11D9-BFB1-000D93589AF6</string>
 			<key>name</key><string>Perl</string>
-			<key>url</key><string>https://github.com/dayglojesus/perl.tmbundle</string>
+			<key>url</key><string>https://github.com/textmatelives/perl.tmbundle</string>
 			<key>ref</key><string>master</string>
 			<key>autoUpdate</key><true/>
 			<key>category</key><string>Languages</string>
@@ -217,31 +217,31 @@
 		<dict>
 			<key>uuid</key><string>467A3CB0-6227-11D9-BFB1-000D93589AF6</string>
 			<key>name</key><string>Property List</string>
-			<key>url</key><string>https://github.com/dayglojesus/property-list.tmbundle</string>
-			<key>ref</key><string>remove-legacy-ruby</string>
+			<key>url</key><string>https://github.com/textmatelives/property-list.tmbundle</string>
+			<key>ref</key><string>main</string>
 			<key>autoUpdate</key><true/>
 			<key>category</key><string>Languages</string>
 		</dict>
 		<dict>
 			<key>uuid</key><string>E3BADC20-6B0E-11D9-9DC9-000D93589AF6</string>
 			<key>name</key><string>Python</string>
-			<key>url</key><string>https://github.com/dayglojesus/python.tmbundle</string>
-			<key>ref</key><string>remove-legacy-ruby</string>
+			<key>url</key><string>https://github.com/textmatelives/python.tmbundle</string>
+			<key>ref</key><string>main</string>
 			<key>autoUpdate</key><true/>
 			<key>category</key><string>Languages</string>
 		</dict>
 		<dict>
 			<key>uuid</key><string>467B298F-6227-11D9-BFB1-000D93589AF6</string>
 			<key>name</key><string>Ruby</string>
-			<key>url</key><string>https://github.com/dayglojesus/ruby.tmbundle</string>
-			<key>ref</key><string>remove-legacy-ruby</string>
+			<key>url</key><string>https://github.com/textmatelives/ruby.tmbundle</string>
+			<key>ref</key><string>main</string>
 			<key>autoUpdate</key><true/>
 			<key>category</key><string>Languages</string>
 		</dict>
 		<dict>
 			<key>uuid</key><string>3BDF79F4-94AE-46C0-BFBF-D5572AD2F515</string>
 			<key>name</key><string>SCM</string>
-			<key>url</key><string>https://github.com/dayglojesus/scm.tmbundle</string>
+			<key>url</key><string>https://github.com/textmatelives/scm.tmbundle</string>
 			<key>ref</key><string>master</string>
 			<key>autoUpdate</key><true/>
 			<key>category</key><string>SCM</string>
@@ -249,39 +249,39 @@
 		<dict>
 			<key>uuid</key><string>AAB4CBF7-73F9-11D9-B89A-000D93589AF6</string>
 			<key>name</key><string>SQL</string>
-			<key>url</key><string>https://github.com/dayglojesus/sql.tmbundle</string>
-			<key>ref</key><string>remove-legacy-ruby</string>
+			<key>url</key><string>https://github.com/textmatelives/sql.tmbundle</string>
+			<key>ref</key><string>main</string>
 			<key>autoUpdate</key><true/>
 			<key>category</key><string>Languages</string>
 		</dict>
 		<dict>
 			<key>uuid</key><string>4694B05E-6227-11D9-BFB1-000D93589AF6</string>
 			<key>name</key><string>Shell Script</string>
-			<key>url</key><string>https://github.com/dayglojesus/shellscript.tmbundle</string>
-			<key>ref</key><string>remove-legacy-ruby</string>
+			<key>url</key><string>https://github.com/textmatelives/shellscript.tmbundle</string>
+			<key>ref</key><string>main</string>
 			<key>autoUpdate</key><true/>
 			<key>category</key><string>Languages</string>
 		</dict>
 		<dict>
 			<key>uuid</key><string>AEAF4DD4-74CD-11D9-BAD4-000A95A89C98</string>
 			<key>name</key><string>Subversion</string>
-			<key>url</key><string>https://github.com/dayglojesus/subversion.tmbundle</string>
-			<key>ref</key><string>remove-legacy-ruby</string>
+			<key>url</key><string>https://github.com/textmatelives/subversion.tmbundle</string>
+			<key>ref</key><string>main</string>
 			<key>autoUpdate</key><true/>
 			<key>category</key><string>SCM</string>
 		</dict>
 		<dict>
 			<key>uuid</key><string>0B296803-7D51-11D9-859D-000D93B6E43C</string>
 			<key>name</key><string>TODO</string>
-			<key>url</key><string>https://github.com/dayglojesus/todo.tmbundle</string>
-			<key>ref</key><string>remove-legacy-ruby</string>
+			<key>url</key><string>https://github.com/textmatelives/todo.tmbundle</string>
+			<key>ref</key><string>main</string>
 			<key>autoUpdate</key><true/>
 			<key>category</key><string>Other</string>
 		</dict>
 		<dict>
 			<key>uuid</key><string>13A041AB-28AA-4170-8DCE-912B90E11C35</string>
 			<key>name</key><string>TOML</string>
-			<key>url</key><string>https://github.com/dayglojesus/toml.tmbundle</string>
+			<key>url</key><string>https://github.com/textmatelives/toml.tmbundle</string>
 			<key>ref</key><string>master</string>
 			<key>autoUpdate</key><true/>
 			<key>category</key><string>Languages</string>
@@ -289,23 +289,23 @@
 		<dict>
 			<key>uuid</key><string>5A9D4FC6-6CBE-11D9-A21B-000D93589AF6</string>
 			<key>name</key><string>TextMate</string>
-			<key>url</key><string>https://github.com/dayglojesus/textmate.tmbundle</string>
-			<key>ref</key><string>remove-legacy-ruby</string>
+			<key>url</key><string>https://github.com/textmatelives/textmate.tmbundle</string>
+			<key>ref</key><string>main</string>
 			<key>autoUpdate</key><true/>
 			<key>category</key><string>Other</string>
 		</dict>
 		<dict>
 			<key>uuid</key><string>4694D53F-6227-11D9-BFB1-000D93589AF6</string>
 			<key>name</key><string>XML</string>
-			<key>url</key><string>https://github.com/dayglojesus/xml.tmbundle</string>
-			<key>ref</key><string>remove-legacy-ruby</string>
+			<key>url</key><string>https://github.com/textmatelives/xml.tmbundle</string>
+			<key>ref</key><string>main</string>
 			<key>autoUpdate</key><true/>
 			<key>category</key><string>Languages</string>
 		</dict>
 		<dict>
 			<key>uuid</key><string>AC506ECC-4F1F-11DA-AFF2-000A95AF0064</string>
 			<key>name</key><string>YAML</string>
-			<key>url</key><string>https://github.com/dayglojesus/yaml.tmbundle</string>
+			<key>url</key><string>https://github.com/textmatelives/yaml.tmbundle</string>
 			<key>ref</key><string>master</string>
 			<key>autoUpdate</key><true/>
 			<key>category</key><string>Languages</string>
@@ -313,7 +313,7 @@
 		<dict>
 			<key>uuid</key><string>473243BE-85DC-4FE3-A8B1-6DF9C4295FEB</string>
 			<key>name</key><string>YAML (ERB)</string>
-			<key>url</key><string>https://github.com/dayglojesus/yaml-erb.tmbundle</string>
+			<key>url</key><string>https://github.com/textmatelives/yaml-erb.tmbundle</string>
 			<key>ref</key><string>main</string>
 			<key>autoUpdate</key><true/>
 			<key>category</key><string>Languages</string>

--- a/Applications/TextMate/resources/DefaultBundles.plist
+++ b/Applications/TextMate/resources/DefaultBundles.plist
@@ -50,7 +50,7 @@
 			<key>uuid</key><string>A46E4382-F1AC-405B-8F22-65FF470F34D7</string>
 			<key>name</key><string>CoffeeScript</string>
 			<key>url</key><string>https://github.com/textmatelives/coffee-script.tmbundle</string>
-			<key>ref</key><string>master</string>
+			<key>ref</key><string>main</string>
 			<key>autoUpdate</key><true/>
 			<key>category</key><string>Languages</string>
 		</dict>
@@ -58,7 +58,7 @@
 			<key>uuid</key><string>7A8214CC-4D64-492C-91A5-F86C666C26B8</string>
 			<key>name</key><string>Cron</string>
 			<key>url</key><string>https://github.com/textmatelives/cron.tmbundle</string>
-			<key>ref</key><string>master</string>
+			<key>ref</key><string>main</string>
 			<key>autoUpdate</key><true/>
 			<key>category</key><string>Languages</string>
 		</dict>
@@ -66,7 +66,7 @@
 			<key>uuid</key><string>C2D2BFF9-708D-11D9-BD09-0011242E4184</string>
 			<key>name</key><string>Diff</string>
 			<key>url</key><string>https://github.com/textmatelives/diff.tmbundle</string>
-			<key>ref</key><string>master</string>
+			<key>ref</key><string>main</string>
 			<key>autoUpdate</key><true/>
 			<key>category</key><string>Languages</string>
 		</dict>
@@ -74,7 +74,7 @@
 			<key>uuid</key><string>065A8821-DD83-4753-90E3-AA70EC12E150</string>
 			<key>name</key><string>Erlang</string>
 			<key>url</key><string>https://github.com/textmatelives/erlang.tmbundle</string>
-			<key>ref</key><string>master</string>
+			<key>ref</key><string>main</string>
 			<key>autoUpdate</key><true/>
 			<key>category</key><string>Languages</string>
 		</dict>
@@ -138,7 +138,7 @@
 			<key>uuid</key><string>5217EA86-3153-4568-B5FD-05917BCE46B3</string>
 			<key>name</key><string>Lua</string>
 			<key>url</key><string>https://github.com/textmatelives/lua.tmbundle</string>
-			<key>ref</key><string>master</string>
+			<key>ref</key><string>main</string>
 			<key>autoUpdate</key><true/>
 			<key>category</key><string>Languages</string>
 		</dict>
@@ -210,7 +210,7 @@
 			<key>uuid</key><string>4679B572-6227-11D9-BFB1-000D93589AF6</string>
 			<key>name</key><string>Perl</string>
 			<key>url</key><string>https://github.com/textmatelives/perl.tmbundle</string>
-			<key>ref</key><string>master</string>
+			<key>ref</key><string>main</string>
 			<key>autoUpdate</key><true/>
 			<key>category</key><string>Languages</string>
 		</dict>
@@ -242,7 +242,7 @@
 			<key>uuid</key><string>3BDF79F4-94AE-46C0-BFBF-D5572AD2F515</string>
 			<key>name</key><string>SCM</string>
 			<key>url</key><string>https://github.com/textmatelives/scm.tmbundle</string>
-			<key>ref</key><string>master</string>
+			<key>ref</key><string>main</string>
 			<key>autoUpdate</key><true/>
 			<key>category</key><string>SCM</string>
 		</dict>
@@ -282,7 +282,7 @@
 			<key>uuid</key><string>13A041AB-28AA-4170-8DCE-912B90E11C35</string>
 			<key>name</key><string>TOML</string>
 			<key>url</key><string>https://github.com/textmatelives/toml.tmbundle</string>
-			<key>ref</key><string>master</string>
+			<key>ref</key><string>main</string>
 			<key>autoUpdate</key><true/>
 			<key>category</key><string>Languages</string>
 		</dict>
@@ -306,7 +306,7 @@
 			<key>uuid</key><string>AC506ECC-4F1F-11DA-AFF2-000A95AF0064</string>
 			<key>name</key><string>YAML</string>
 			<key>url</key><string>https://github.com/textmatelives/yaml.tmbundle</string>
-			<key>ref</key><string>master</string>
+			<key>ref</key><string>main</string>
 			<key>autoUpdate</key><true/>
 			<key>category</key><string>Languages</string>
 		</dict>

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Fork constraints
 
-This is `dayglojesus/textmate`, a fork of `textmate/textmate` targeting macOS 26 / Apple Silicon.
+This is `textmatelives/textmate`, a fork of `textmate/textmate` targeting macOS 26 / Apple Silicon.
 
 Hard constraints declared by the maintainer:
 - arm64 only — do not add x86_64 fallbacks
@@ -60,7 +60,7 @@ Tests that shell out to git must call `git init -b master` (not bare `git init`)
 
 ## Bundle delivery
 
-The fork uses forked bundles under `~/src/github.com/dayglojesus/bundles/` and `bundle-support.tmbundle`, ported to Ruby 2.6.10. Local dev wires them in via symlinks in `~/Library/Application Support/TextMate/Managed/Bundles/` — `bin/reset_bundles.sh` performs that wiring.
+The fork uses forked bundles under `~/src/github.com/textmatelives/bundles/` and `bundle-support.tmbundle`, ported to Ruby 2.6.10. Local dev wires them in via symlinks in `~/Library/Application Support/TextMate/Managed/Bundles/` — `bin/reset_bundles.sh` performs that wiring.
 
 `REST_API` is still hardcoded at `default.rave:12` and `BundlesManager.mm` still polls every 3h via `NSBackgroundActivityScheduler`. The Managed/Bundles symlink approach side-steps this for development; packaging for distribution is unresolved.
 

--- a/Frameworks/BundlesManager/src/MandatoryBundles.h
+++ b/Frameworks/BundlesManager/src/MandatoryBundles.h
@@ -22,27 +22,27 @@ struct TMMandatoryBundle
 };
 
 static struct TMMandatoryBundle const kTMMandatoryBundles[] = {
-	// branch: remove-legacy-ruby
+	// branch: main
 	{
 		"0BB1F01A-4F0A-475A-ACDD-0F5578F2EFC3",
 		"Bundle Support",
-		"https://github.com/dayglojesus/bundle-support.tmbundle",
+		"https://github.com/textmatelives/bundle-support.tmbundle",
 		"7c779d06bab86a9e0d5d9d7121d43ce9869e9856",
 		"Other",
 	},
-	// branch: remove-legacy-ruby
+	// branch: main
 	{
 		"B7BC3FFD-6E4B-11D9-91AF-000D93589AF6",
 		"Text",
-		"https://github.com/dayglojesus/text.tmbundle",
+		"https://github.com/textmatelives/text.tmbundle",
 		"34ab58910c42f53798f19dd2cba3d7732a3e8d03",
 		"Other",
 	},
-	// branch: remove-legacy-ruby
+	// branch: main
 	{
 		"4F45FDC0-62CA-4786-9134-8BC7C1F5606F",
 		"Source",
-		"https://github.com/dayglojesus/source.tmbundle",
+		"https://github.com/textmatelives/source.tmbundle",
 		"2c873f8382fd11cda4a86b4159bc2977577568d3",
 		"Other",
 	},

--- a/bin/build_filetype_index.rb
+++ b/bin/build_filetype_index.rb
@@ -1,7 +1,7 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
-# Build BundleFileTypeIndex.plist from the dayglojesus bundle source tree.
+# Build BundleFileTypeIndex.plist from the textmatelives bundle source tree.
 #
 # Walks each *.tmbundle/ directory, reads info.plist (uuid + name) and any
 # Syntaxes/*.{plist,tmLanguage,tmLanguage.json} files for fileTypes + scopeName.
@@ -9,8 +9,8 @@
 # priority. Same-tier collisions abort unless listed in COLLISION_TIEBREAK.
 #
 # Run:
-#   BUNDLES_DIR=~/src/github.com/dayglojesus/bundles \
-#   BUNDLE_SUPPORT_DIR=~/src/github.com/dayglojesus/bundle-support.tmbundle \
+#   BUNDLES_DIR=~/src/github.com/textmatelives/bundles \
+#   BUNDLE_SUPPORT_DIR=~/src/github.com/textmatelives/bundle-support.tmbundle \
 #   ruby bin/build_filetype_index.rb
 
 require 'rexml/document'
@@ -39,11 +39,11 @@ def textmate_root
 end
 
 def bundles_dir
-  ENV['BUNDLES_DIR'] || File.expand_path('~/src/github.com/dayglojesus/bundles')
+  ENV['BUNDLES_DIR'] || File.expand_path('~/src/github.com/textmatelives/bundles')
 end
 
 def bundle_support_dir
-  ENV['BUNDLE_SUPPORT_DIR'] || File.expand_path('~/src/github.com/dayglojesus/bundle-support.tmbundle')
+  ENV['BUNDLE_SUPPORT_DIR'] || File.expand_path('~/src/github.com/textmatelives/bundle-support.tmbundle')
 end
 
 # Parse any .plist file to a Ruby object via `plutil -convert xml1 -o - <file>`.

--- a/bin/generate_available_bundles.rb
+++ b/bin/generate_available_bundles.rb
@@ -6,7 +6,7 @@
 #   <dict>
 #     <key>uuid</key><string>UUID</string>
 #     <key>name</key><string>Name</string>
-#     <key>url</key><string>https://github.com/dayglojesus/repo</string>
+#     <key>url</key><string>https://github.com/textmatelives/repo</string>
 #     <key>ref</key><string>master|remove-legacy-ruby|python3-port|arm64-binaries</string>
 #     <key>autoUpdate</key><true/>
 #     <key>category</key><string>Build|Languages|SCM|Other|Themes|Testing</string>
@@ -28,7 +28,7 @@ DEFERRED_UUIDS = %w[
   F80D3822-6EE8-11D9-BF2D-000D93589AF6
 ].freeze
 
-# Branch ref per fork (keyed by dayglojesus fork name without owner prefix).
+# Branch ref per fork (keyed by textmatelives fork name without owner prefix).
 # Default is 'master' for any fork not listed here.
 ARM64_BRANCH = %w[
   latex.tmbundle
@@ -80,7 +80,7 @@ RUBY18_BRANCH = %w[
   vagrant.tmbundle
 ].freeze
 
-# Upstream basename → dayglojesus fork basename (collision-rename overrides).
+# Upstream basename → textmatelives fork basename (collision-rename overrides).
 FORK_RENAMES = {
   'rspec-tmbundle' => 'rspec.tmbundle',
 }.freeze
@@ -142,7 +142,7 @@ end
 
 def render_entry(uuid:, name:, fork:, ref:, category:, summary:)
   esc = ->(s) { s.gsub('&', '&amp;').gsub('<', '&lt;').gsub('>', '&gt;') }
-  url = "https://github.com/dayglojesus/#{fork}"
+  url = "https://github.com/textmatelives/#{fork}"
   desc_line = summary && !summary.empty? ?
     "\n\t\t\t<key>description</key><string>#{esc.call(summary)}</string>" :
     ''

--- a/bin/reset_bundles.sh
+++ b/bin/reset_bundles.sh
@@ -8,8 +8,8 @@
 set -e
 
 MANAGED="$HOME/Library/Application Support/TextMate/Managed/Bundles"
-REPOS="$HOME/src/github.com/dayglojesus/bundles"
-SUPPORT_REPO="$HOME/src/github.com/dayglojesus/bundle-support.tmbundle"
+REPOS="$HOME/src/github.com/textmatelives/bundles"
+SUPPORT_REPO="$HOME/src/github.com/textmatelives/bundle-support.tmbundle"
 
 # Map managed bundle directory names to repo directory names
 map_name() {


### PR DESCRIPTION
## Summary

Post-migration catalogue cleanup so installs resolve against `textmatelives` and the bundle-side `main` rename. Two commits:

**1. Update fork references: `textmatelives` org and `main` branch** (`d5f2ec3`)

- Catalogue URLs (`DefaultBundles.plist`, `AvailableBundles.plist`, `MandatoryBundles.h`): `github.com/dayglojesus` → `github.com/textmatelives`.
- Catalogue `ref` values in plists: `remove-legacy-ruby` / `python3-port` / `arm64-binaries` → `main`, matching the bundle-side rename.
- `MandatoryBundles.h` `// branch:` comments updated; pinned SHAs unchanged (still reachable from each bundle's `main`).
- `CLAUDE.md`, `bin/build_filetype_index.rb`, `bin/reset_bundles.sh`, `bin/generate_available_bundles.rb`: doc and local-dev-path references updated to `textmatelives`.

**2. Bundles catalogue: stale `ref=master` → `ref=main`** (`e6677d1a`)

The first pass only touched the explicit fork-branch refs. But the bundle-side cleanup mass-renamed `master` → `main` across all 157 textmatelives bundles, leaving 80 catalogue entries pointing at a branch that no longer exists. App `BundleFetcher` 404'd silently — fresh-install test attempted 153 entries and 80 failed with no log signal. Sweeps both plists:

```
<key>ref</key><string>master</string>  →  <key>ref</key><string>main</string>
```

## Verification

CI green. Local fresh-build verified the embedded plists:

| Plist | stale `master` refs | `main` refs | `dayglojesus` URLs | `textmatelives` URLs |
|---|---|---|---|---|
| DefaultBundles.plist | 0 | 39 | 0 | 39 |
| AvailableBundles.plist | 0 | 110 | 0 | 110 |

## Test plan

- [x] CI (`build-test`) green on `e6677d1a`.
- [x] Local from-scratch rebuild after full TextMate state scrub (prefs, caches, Application Support, HTTPStorages, WebKit).
- [x] Embedded catalogue plists show 0 stale refs, 0 dayglojesus URLs.
- [ ] Post-merge: launch fresh app and confirm bundle installs complete without silent 404s.