### PR TITLE
Surface CHANGELOG content in GitHub release notes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [main]
     paths:
-      - Applications/TextMate/about/Changes.md
+      - CHANGELOG.md
   workflow_dispatch:
     inputs:
       reason:
@@ -29,14 +29,14 @@ jobs:
           submodules: recursive
           fetch-depth: 0
 
-      - name: Extract version from Changes.md
+      - name: Extract version from CHANGELOG.md
         id: version
         run: |
           set -euo pipefail
-          VERSION=$(grep -om1 '^## .* (v.*)$' Applications/TextMate/about/Changes.md \
+          VERSION=$(grep -om1 '^## .* (v.*)$' CHANGELOG.md \
                     | sed 's/.*(v\(.*\))/\1/')
           if [ -z "$VERSION" ]; then
-            echo "::error::No version line found in Applications/TextMate/about/Changes.md"
+            echo "::error::No version line found in CHANGELOG.md"
             exit 1
           fi
           echo "Detected: v${VERSION}"
@@ -248,6 +248,20 @@ jobs:
             "$(basename '${{ steps.app.outputs.app_path }}')"
           echo "archive=$ARCHIVE" >> "$GITHUB_OUTPUT"
 
+      - name: Extract release notes for v${VERSION}
+        if: steps.tagcheck.outputs.should_release == 'true'
+        id: notes
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          set -euo pipefail
+          NOTES_FILE="$RUNNER_TEMP/release-notes.md"
+          bin/extract_changes -v "$VERSION" -o "$NOTES_FILE" CHANGELOG.md
+          echo "::group::Extracted release notes"
+          cat "$NOTES_FILE"
+          echo "::endgroup::"
+          echo "notes_file=$NOTES_FILE" >> "$GITHUB_OUTPUT"
+
       - name: Create GitHub release
         if: steps.tagcheck.outputs.should_release == 'true'
         env:
@@ -257,6 +271,7 @@ jobs:
           gh release create "v${VERSION}" \
             --target "${GITHUB_SHA}" \
             --title "TextMate ${VERSION}" \
+            --notes-file "${{ steps.notes.outputs.notes_file }}" \
             --generate-notes \
             "${{ steps.archive.outputs.archive }}"
 


### PR DESCRIPTION
## Summary

- Switches the release workflow to use `CHANGELOG.md` (root) instead of `Applications/TextMate/about/Changes.md` for both the trigger path and the version-extract grep. The release PR that follows will add `CHANGELOG.md`; until then the trigger is dormant.
- Adds an _Extract release notes_ step that runs `bin/extract_changes` to pull just the current version's section out of `CHANGELOG.md`.
- `gh release create` now combines `--notes-file <extracted>` with `--generate-notes`, so the published release body shows our curated section followed by GitHub's auto-generated PR/contributor list and Full Changelog link.

## Verification

Throwaway `gh release create v2.1.0-undead-localtest --draft --notes-file <extracted> --generate-notes` against this repo confirmed the rendered body is the curated CHANGELOG section followed by `## What's Changed` / `## New Contributors` / `**Full Changelog**`. Draft and tag both cleaned up after the test.

## Test plan

- [ ] Workflow remains dormant on `main` (no `CHANGELOG.md` modifications) until the v2.1.0-undead release PR lands
- [ ] Once that PR merges, this workflow fires, extracts the right section, and publishes the release with both halves of the body