### PR TITLE
Bump CI/release runners to macos-26-arm64

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build-test:
-    runs-on: macos-14   # Apple Silicon
+    runs-on: macos-26   # Xcode 26.4.1 default → actool .icon support
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   release:
-    runs-on: macos-14
+    runs-on: macos-26
     timeout-minutes: 60
     permissions:
       contents: write


### PR DESCRIPTION
## Summary

The new `CompileIcon` rule in `bin/rave` (added in 05f7d6b1, on `release-v2.1.0-undead`) compiles an Icon Composer `.icon` source via `actool`. `actool` only understands `.icon` source bundles starting with Xcode 26 (the Liquid Glass icon format). `macos-14` ships Xcode 15.4, so CI fails on the icon step.

`macos-26-arm64` ships Xcode 26 (default 26.4.1). Bump both `ci.yml` and `release.yml` to the new label.

## Test plan

- [ ] `build-test` passes on this PR (which exercises the new runner against current `main` — no icon source in tree yet, so this validates the runner switch hasn't broken anything else)
- [ ] After merge + rebase of `release-v2.1.0-undead`, the release PR's CI passes (this is where the icon actually gets compiled)