### PR TITLE
release.yml: re-seal nested bundles before signing outer .app

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -161,6 +161,25 @@ jobs:
                      -o -path "*/PlugIns/*" \) -print0)
           echo "Re-signed $count Mach-O files"
 
+      - name: Re-seal nested bundles (after modifying their contents)
+        if: steps.tagcheck.outputs.should_release == 'true'
+        run: |
+          set -euo pipefail
+          APP="${{ steps.app.outputs.app_path }}"
+          # Re-signing Mach-O binaries inside a signed bundle (e.g.
+          # Dialog.tmplugin/Contents/Resources/tm_dialog) invalidates the
+          # bundle's CodeResources seal. Each enclosing bundle must be
+          # codesigned again, inside-out, before we re-sign the outer .app.
+          count=0
+          while IFS= read -r -d '' b; do
+            codesign --force --sign "$CS_IDENTITY" --options runtime --timestamp "$b"
+            count=$((count+1))
+          done < <(find "$APP/Contents" \
+                     \( -name "*.tmplugin" -o -name "*.framework" \
+                     -o -name "*.qlgenerator" -o -name "*.appex" \) \
+                     -type d -print0)
+          echo "Re-sealed $count nested bundles"
+
       - name: Re-sign outer .app with entitlements (after modifying contents)
         if: steps.tagcheck.outputs.should_release == 'true'
         run: |


### PR DESCRIPTION
## Summary

Fixes the codesign verify failure in run [26369885190](https://github.com/textmatelives/textmate/actions/runs/26369885190):

```
TextMate.app: a sealed resource is missing or invalid
file modified: …/PlugIns/Dialog.tmplugin/Contents/Resources/tm_dialog
In subcomponent: …/PlugIns/Dialog.tmplugin
```

The "Re-sign every embedded Mach-O" step finds `tm_dialog` via the `*/PlugIns/*` glob and codesigns it. That invalidates `Dialog.tmplugin`'s CodeResources seal — `.tmplugin` is itself a signed bundle. The next step re-signs the outer .app but never re-seals the intermediate `.tmplugin`, so verify catches the broken seal.

Codesigning needs inside-out ordering: leaf Mach-O → nested bundles → outer .app. Adds a new step between the Mach-O re-sign and the outer-.app re-sign that codesigns every `.tmplugin`, `.framework`, `.qlgenerator`, and `.appex` directory under `Contents/`. Currently three: `Dialog.tmplugin`, `Dialog2.tmplugin`, `TextMateQL.qlgenerator`.

## Test plan

- [ ] `build-test` passes on this PR
- [ ] After merge, re-trigger the release via `workflow_dispatch` on `release.yml` (since `CHANGELOG.md` is already on `main` and won't push-trigger again)
- [ ] Verify codesign step passes
- [ ] Notarization completes, `gh release create` publishes the asset