### PR TITLE
Info.plist: declare CFBundleSupportedPlatforms = [MacOSX] (fixes #8)

### DIFF
--- a/Applications/TextMate/Info.plist
+++ b/Applications/TextMate/Info.plist
@@ -26,6 +26,10 @@
 	<string>APPL</string>
 	<key>CFBundleSignature</key>
 	<string>avin</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>MacOSX</string>
+	</array>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.developer-tools</string>
 	<key>LSMinimumSystemVersion</key>


### PR DESCRIPTION
Fixes #8.

On Apple Silicon, `TextMate.app` was reported by System Profiler (Software ▸ Applications ▸ Kind) as an **iOS** app (`arch_ios`) rather than **Apple Chips** (`arch_arm`). The cause is a missing `CFBundleSupportedPlatforms` key in the bundle's `Info.plist`; without it, LaunchServices / System Profiler can misclassify a native arm64 macOS app as iOS.

### Fix
Declare macOS as the only supported platform:

```xml
<key>CFBundleSupportedPlatforms</key>
<array>
    <string>MacOSX</string>
</array>
```

This is the same one-key metadata fix adopted for the identical symptom by LibreOffice, VS Code, GIMP, Zed, Servo, and CPython (references in #8). Apple's own apps ship this key. The change is additive static metadata and does not affect code signing or notarization.

### Test plan
- Build, then run: `system_profiler SPApplicationsDataType -xml | grep TextMate -A 9 -B 2` → shows `arch_arm` / "Apple Chips".

Thanks to @sierkb for the detailed report and the proposed fix.
