### PR TITLE
configure: use Homebrew prefix so the README build works on Apple Silicon

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,13 +18,8 @@ jobs:
       - name: Install build dependencies
         run: brew install boost google-sparsehash multimarkdown ninja ragel mercurial subversion
 
-      - name: Pre-seed local.rave for arm64 Homebrew prefix
-        run: |
-          cat > local.rave <<'EOF'
-          add FLAGS    "-I/opt/homebrew/include"
-          add LN_FLAGS "-L/opt/homebrew/lib"
-          EOF
-
+      # No local.rave pre-seed: configure now derives the Homebrew prefix itself,
+      # so this step exercises that path on a clean arm64 runner.
       - name: Configure
         run: ./configure
 

--- a/configure
+++ b/configure
@@ -10,14 +10,22 @@ for dep in ninja ragel multimarkdown pgrep pkill; do
 	which -s "$dep" || error "*** dependency missing: ‘${dep}’."
 done
 
+# Resolve the dependency prefix. Homebrew installs under /opt/homebrew on Apple
+# Silicon and /usr/local on Intel; query it when available, otherwise default to
+# /usr/local (MacPorts users may need to adjust ‘local.rave’ by hand).
+prefix="/usr/local"
+if which -s brew; then
+	prefix="$(brew --prefix 2>/dev/null || echo /usr/local)"
+fi
+
 if [[ -e local.rave ]]; then
 	echo >&2 "Skipping writing ‘local.rave’: File already exists"
 else
-	echo >> local.rave 'add FLAGS    "-I/usr/local/include"'
-	echo >> local.rave 'add LN_FLAGS "-L/usr/local/lib"'
+	echo >> local.rave "add FLAGS    \"-I${prefix}/include\""
+	echo >> local.rave "add LN_FLAGS \"-L${prefix}/lib\""
 
 	for hdr in boost/{crc,variant}.hpp sparsehash/dense_hash_map; do
-		test -f "/usr/local/include/${hdr}" || error "*** dependency missing: ‘/usr/local/include/${hdr}’. Install dependency and/or update ‘local.rave’ with correct path."
+		test -f "${prefix}/include/${hdr}" || error "*** dependency missing: ‘${prefix}/include/${hdr}’. Install dependency and/or update ‘local.rave’ with correct path."
 	done
 fi
 


### PR DESCRIPTION
## Problem
`README.md` mandates Apple Silicon, where Homebrew installs under `/opt/homebrew`, but `configure` hardcoded `/usr/local` for the generated `local.rave` and the boost/sparsehash header checks. A fresh clone following the README therefore failed at `./configure` with `*** dependency missing: '/usr/local/include/boost/crc.hpp'`.

## Fix
`configure` now derives the prefix from `brew --prefix` when Homebrew is present (covers `/opt/homebrew` on Apple Silicon and `/usr/local` on Intel), falling back to `/usr/local`.

## Confirmation via CI
CI previously pre-seeded `local.rave` with the same two `/opt/homebrew` lines, which bypassed the path being fixed. This PR drops that pre-seed so CI runs `./configure` for real on a clean `macos-26` (arm64) runner. The auto-generated `local.rave` is byte-for-byte identical to the pre-seed it replaced, so a green run confirms the fix on a machine independent of the author's.

`release.yml`'s pre-seed is left in place — it also sets the signing identity and hardened-runtime flags, which `configure` does not generate.
