### PR TITLE
ci: isolate build/test into a reusable workflow and gate releases on it

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,0 +1,63 @@
+name: Build and Test
+
+# Reusable workflow: isolates build and test into two independent jobs so a
+# caller (ci.yml on PRs, release.yml as a release gate) can require BOTH to
+# pass. Invoked via `uses: ./.github/workflows/build-and-test.yml`.
+on:
+  workflow_call:
+
+jobs:
+  build:
+    runs-on: macos-26   # Xcode 26.4.1 default → actool .icon support
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Install build dependencies
+        run: brew install boost google-sparsehash multimarkdown ninja ragel mercurial subversion
+
+      # No local.rave pre-seed: configure now derives the Homebrew prefix itself,
+      # so this step exercises that path on a clean arm64 runner.
+      - name: Configure
+        run: ./configure
+
+      - name: Build TextMate.app
+        run: ninja TextMate
+
+  test:
+    runs-on: macos-26   # Xcode 26.4.1 default → actool .icon support
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Install build dependencies
+        run: brew install boost google-sparsehash multimarkdown ninja ragel mercurial subversion
+
+      # No local.rave pre-seed: configure now derives the Homebrew prefix itself,
+      # so this step exercises that path on a clean arm64 runner.
+      - name: Configure
+        run: ./configure
+
+      - name: Discover and run all framework tests
+        run: |
+          # Excluded:
+          #   buffer  - 3 spellcheck tests need NSSpellChecker dictionary (no headless support)
+          #   cf,
+          #   layout  - pure C++ data-structure tests trap/segfault under parallel runner on
+          #             macos-14 (.cc tests run parallel; .mm get --no-parallel via rave:1454)
+          #   command,
+          #   editor  - both call runner_t::launch() + wait_for_command(); wait() polls NSApp
+          #             events and a worker-thread runloop. With NSApp nil in a CLI binary the
+          #             completion path never fires and the test hangs to job timeout.
+          #   file    - test_save_translit relies on iconv //TRANSLIT behavior that differs
+          #             between macOS 14.5 (runner SDK) and macOS 26 (local).
+          TESTS=$(grep -lE '^[[:space:]]*tests[[:space:]]' Frameworks/*/default.rave \
+                  | xargs -n1 dirname | xargs -n1 basename \
+                  | grep -vE '^(buffer|cf|command|editor|file|layout)$' \
+                  | sed 's|$|/test|')
+          echo "Running tests: $TESTS"
+          ninja $TESTS

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,41 +7,11 @@ on:
     branches: [main]
 
 jobs:
-  build-test:
-    runs-on: macos-26   # Xcode 26.4.1 default → actool .icon support
-    timeout-minutes: 15
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          submodules: recursive
-
-      - name: Install build dependencies
-        run: brew install boost google-sparsehash multimarkdown ninja ragel mercurial subversion
-
-      # No local.rave pre-seed: configure now derives the Homebrew prefix itself,
-      # so this step exercises that path on a clean arm64 runner.
-      - name: Configure
-        run: ./configure
-
-      - name: Build TextMate.app
-        run: ninja TextMate
-
-      - name: Discover and run all framework tests
-        run: |
-          # Excluded:
-          #   buffer  - 3 spellcheck tests need NSSpellChecker dictionary (no headless support)
-          #   cf,
-          #   layout  - pure C++ data-structure tests trap/segfault under parallel runner on
-          #             macos-14 (.cc tests run parallel; .mm get --no-parallel via rave:1454)
-          #   command,
-          #   editor  - both call runner_t::launch() + wait_for_command(); wait() polls NSApp
-          #             events and a worker-thread runloop. With NSApp nil in a CLI binary the
-          #             completion path never fires and the test hangs to job timeout.
-          #   file    - test_save_translit relies on iconv //TRANSLIT behavior that differs
-          #             between macOS 14.5 (runner SDK) and macOS 26 (local).
-          TESTS=$(grep -lE '^[[:space:]]*tests[[:space:]]' Frameworks/*/default.rave \
-                  | xargs -n1 dirname | xargs -n1 basename \
-                  | grep -vE '^(buffer|cf|command|editor|file|layout)$' \
-                  | sed 's|$|/test|')
-          echo "Running tests: $TESTS"
-          ninja $TESTS
+  # Delegates to the reusable workflow, which runs `build` and `test` as two
+  # independent jobs. Both must pass for a PR to be viable. The check contexts
+  # GitHub reports are `build-and-test / build` and `build-and-test / test`
+  # (i.e. <this-job-id> / <reusable-job-id>) — required-status-check names on
+  # `main` must be updated to match (the old single `build-test` context is no
+  # longer produced).
+  build-and-test:
+    uses: ./.github/workflows/build-and-test.yml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,14 @@ on:
         default: manual release
 
 jobs:
+  # Fresh build + test gate. A release must not ship an untested build, so the
+  # publish job below depends on this. Reuses the same isolated build/test jobs
+  # as CI via the reusable workflow (`build` and `test`, each on macos-26).
+  verify:
+    uses: ./.github/workflows/build-and-test.yml
+
   release:
+    needs: verify   # publish only if build AND test passed
     runs-on: macos-26
     timeout-minutes: 60
     permissions:

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -22,7 +22,7 @@ with the same `grep`/`sed`:
   `:20` passes it as `APP_VERSION` into `Info.plist` (`Info.plist:8` is
   `<string>${APP_VERSION}</string>`).
 - The release workflow, for the git tag, the release title, and the release
-  notes (`release.yml:32-43`).
+  notes (`release.yml:39-50`).
 
 Because both read the same heading, the shipped app reports exactly the version
 in the tag — important so the updater does not offer a release to itself.
@@ -40,8 +40,10 @@ The `-undead` suffix is **required** (see the guard below).
 1. Add a new entry to the **top** of `CHANGELOG.md`, above the previous one:
    `## YYYY-MM-DD (vX.Y.Z-undead)`, followed by `### Section` headings and
    `*` bullets. Reference PRs/issues and commit SHAs (see existing entries).
-2. Open a PR from a branch. CI (`ci.yml`) builds and tests; it does **not**
-   publish.
+2. Open a PR from a branch. CI (`ci.yml`) calls the reusable workflow
+   `build-and-test.yml`, which runs `build` and `test` as two independent jobs;
+   both must pass. It does **not** publish. (The required status checks on
+   `main` are `build-and-test / build` and `build-and-test / test`.)
 3. Verify the notes render as intended:
    `bin/extract_changes -v X.Y.Z-undead -o - CHANGELOG.md`.
 4. Merge the PR to `main`. The push to `main` touching `CHANGELOG.md` triggers
@@ -56,34 +58,46 @@ but it still reads the version from the current `CHANGELOG.md` top entry.
 
 ## What the workflow does (`release.yml`)
 
-Runs on `macos-26`, 60-minute timeout, `contents: write`.
+The release is a single gated pipeline. A `verify` job runs first; the `release`
+job that signs, notarizes, and publishes declares `needs: verify`, so publish
+only happens if build **and** test pass.
 
-1. **Extract version** from `CHANGELOG.md` (`:32-43`).
-2. **Guard — must be `-undead`** (`:45-59`). If the top version does not contain
+0. **Verify (fresh build + test gate)** — the `verify` job calls the same
+   reusable workflow as CI (`uses: ./.github/workflows/build-and-test.yml`),
+   running the `build` and `test` jobs on `macos-26`. The publish job below has
+   `needs: verify`, so nothing is signed or released unless both pass.
+
+The `release` job runs on `macos-26`, 60-minute timeout, `contents: write`. It
+performs its **own fresh** `./configure` + `ninja TextMate` (it does not reuse
+the `verify` job's build artifact — the signed/notarized build must be built
+fresh in this job):
+
+1. **Extract version** from `CHANGELOG.md` (`:39-50`).
+2. **Guard — must be `-undead`** (`:52-66`). If the top version does not contain
    `-undead`, the run skips (no release).
-3. **Skip if the tag already exists** on `origin` (`:61-74`). Re-running for an
+3. **Skip if the tag already exists** on `origin` (`:68-81`). Re-running for an
    already-released version is a no-op.
-4. **Install deps** via Homebrew (`:76-78`).
+4. **Install deps** via Homebrew (`:83-85`).
 5. **Import the Developer ID certificate** from secrets into an ephemeral
-   keychain and resolve the signing identity (`:80-109`).
+   keychain and resolve the signing identity (`:87-116`).
 6. **Pre-seed `local.rave`** with the Homebrew prefix, the signing identity, and
    hardened-runtime codesign flags, then `./configure` and `ninja TextMate`
-   (`:111-127`). (This pre-seed is intentional and distinct from the local
+   (`:118-134`). (This pre-seed is intentional and distinct from the local
    developer flow, where `configure` derives the prefix itself.)
 7. **Sign inside-out**: re-sign every embedded Mach-O, re-seal nested bundles,
    then re-sign the outer `.app` with release entitlements
-   (`CS_GET_TASK_ALLOW=false`) (`:143-194`), and verify codesign + hardened
-   runtime (`:196-202`).
+   (`CS_GET_TASK_ALLOW=false`) (`:150-201`), and verify codesign + hardened
+   runtime (`:203-209`).
 8. **Notarize** via `notarytool submit --wait`, parsing the JSON status
    (`--wait` can exit 0 on `Invalid`, so the status is checked explicitly)
-   (`:204-233`).
+   (`:211-240`).
 9. **Staple** the ticket (retried until CloudKit propagates) and **verify
-   Gatekeeper** with `spctl --assess` (`:235-255`).
-10. **Build the `.tbz`** `TextMate-${VERSION}.tbz` (`:257-268`).
-11. **Extract release notes** with `bin/extract_changes` (`:270-282`).
+   Gatekeeper** with `spctl --assess` (`:242-262`).
+10. **Build the `.tbz`** `TextMate-${VERSION}.tbz` (`:264-275`).
+11. **Extract release notes** with `bin/extract_changes` (`:277-289`).
 12. **Create the GitHub Release** with `gh release create "v${VERSION}"` — no
-    `--prerelease`/`--draft`, so it becomes `releases/latest` (`:284-295`).
-13. **Delete the ephemeral keychain** (always) (`:297-299`).
+    `--prerelease`/`--draft`, so it becomes `releases/latest` (`:291-302`).
+13. **Delete the ephemeral keychain** (always) (`:304-306`).
 
 ## Required GitHub secrets
 


### PR DESCRIPTION
## The defect

`release.yml` runs **no tests**. It fires independently of `ci.yml` whenever `CHANGELOG.md` changes on `main`, then builds, signs, notarizes, and publishes — so a release can ship a build that was never tested. A green PR and a release are two unrelated pipelines today.

## The change

**Isolate build and test.** New reusable workflow `.github/workflows/build-and-test.yml` (`on: workflow_call`) with two independent jobs on `macos-26`:

- `build`: checkout + brew deps + `./configure` + `ninja TextMate`
- `test`: checkout + brew deps + `./configure` + the existing framework-test discovery/exclusion/run block (moved verbatim; the buffer/cf/command/editor/file/layout exclusion rationale is preserved)

**PRs require both.** `ci.yml` now delegates to that reusable workflow on `push: [main]` and `pull_request: [main]`. A PR is viable only when `build` and `test` both pass.

**Releases are a single gated pipeline.** `release.yml` gains a `verify` job (the same reusable workflow); the existing sign/notarize/publish job now declares `needs: verify`. Pipeline:

```
verify (build + test) -> release: fresh build -> sign -> notarize -> publish
```

`gh release create` runs only if build and test pass. The release job still does its own fresh `./configure` + `ninja TextMate` and full inside-out signing — it does **not** reuse the verify artifact, by design. The `-undead` guard and tag-exists skip still gate every publish step.

`docs/RELEASING.md` is updated to describe the gate and the fresh-build requirement.

## REQUIRED before merge: update `main` branch protection

This renames the required status check. The old `build-test` context is **no longer produced**. Update `main`'s required checks from `build-test` to:

- `build-and-test / build`
- `build-and-test / test`

(keep `strict: true`). Until then, merges block on the now-nonexistent `build-test`. Confirm the exact context strings from this PR's Checks tab before pinning them.

## Validation

All three workflow files YAML-parse clean. GitHub Actions workflows can only be truly exercised by running on GitHub, so this was validated by parse + structural review; the first run on this PR is the real test. Two things to watch: (1) the `test` job runs `ninja $TESTS` without a prior `ninja TextMate` — expected to be fine since ninja builds the test targets' dependencies; (2) a non-`-undead` `CHANGELOG.md` push now runs a full `verify` before the `-undead` guard skips publishing.
