### PR TITLE
ci: bump actions/checkout v4 -> v5 (Node 24 runtime)

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: macos-26   # Xcode 26.4.1 default → actool .icon support
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           submodules: recursive
 
@@ -30,7 +30,7 @@ jobs:
     runs-on: macos-26   # Xcode 26.4.1 default → actool .icon support
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           submodules: recursive
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
       CERT_IDENTITY_NAME: "Developer ID Application"
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           submodules: recursive
           fetch-depth: 0


### PR DESCRIPTION
## Why

`actions/checkout@v4` runs on the deprecated Node.js 20 runtime. GitHub is migrating the Actions runtime to Node 24 and emits a deprecation warning on every job (visible as annotations on recent `build-and-test` runs). `actions/checkout@v5` and later declare `using: node24`.

## Change

Bumps the three `actions/checkout` pins from `@v4` to `@v5`:

- `.github/workflows/build-and-test.yml` — `build` and `test` jobs
- `.github/workflows/release.yml`

Our only checkout option is `submodules: recursive` (plus `fetch-depth: 0` in release), unchanged across the v4→v5 major. Latest is v6.0.2; v5 is the conservative minimal fix that clears the Node 20 deprecation. This PR's own CI run exercises v5.

The unrelated "ninja … already installed" brew annotation is intentionally left as-is — it is harmless runner-image noise (`brew install` of a preinstalled tool warns but exits 0).
