### PR TITLE
scm: bound wait_for_status to fix CI hang

### DIFF
--- a/Frameworks/FileBrowser/tests/t_scm_repository.mm
+++ b/Frameworks/FileBrowser/tests/t_scm_repository.mm
@@ -38,7 +38,7 @@ void test_scm_repository_observes_cxx_info ()
 	// same info_t and will have its callback fired in the meantime.
 	scm::info_ptr info = scm::info(jail.path());
 	OAK_ASSERT(info);
-	scm::wait_for_status(info);
+	OAK_ASSERT(scm::wait_for_status(info));
 
 	NSURL* url = [NSURL fileURLWithPath:[NSString stringWithUTF8String:jail.path().c_str()] isDirectory:YES];
 	SCMRepository* repository = [SCMManager.sharedInstance repositoryAtURL:url];

--- a/Frameworks/scm/src/scm.cc
+++ b/Frameworks/scm/src/scm.cc
@@ -435,7 +435,7 @@ namespace scm
 		return res;
 	}
 
-	void wait_for_status (info_ptr info)
+	bool wait_for_status (info_ptr info, CFTimeInterval timeout)
 	{
 		__block bool shouldWait = true;
 		CFRunLoopRef runLoop = CFRunLoopGetCurrent();
@@ -445,10 +445,22 @@ namespace scm
 			CFRunLoopStop(runLoop);
 		});
 
+		// Bounded wait: drive the run loop in chunks until the callback
+		// fires or the deadline passes. Without this bound the loop could
+		// spin forever waiting on an FSEvents notification that never
+		// arrives — see WISHLIST / HANDOFF for the GitHub Actions hangs
+		// (PR #9 and PR #17 merge runs).
+		CFAbsoluteTime const deadline = CFAbsoluteTimeGetCurrent() + timeout;
 		while(shouldWait)
-			CFRunLoopRun();
+		{
+			CFTimeInterval const remaining = deadline - CFAbsoluteTimeGetCurrent();
+			if(remaining <= 0)
+				break;
+			CFRunLoopRunInMode(kCFRunLoopDefaultMode, remaining, false);
+		}
 
 		info->pop_callback();
+		return !shouldWait;
 	}
 
 } /* scm */

--- a/Frameworks/scm/src/scm.h
+++ b/Frameworks/scm/src/scm.h
@@ -2,6 +2,7 @@
 #define SCM_NG_H_FXJGXN9B
 
 #include "status.h"
+#include <CoreFoundation/CoreFoundation.h>
 
 namespace scm
 {
@@ -48,7 +49,13 @@ namespace scm
 	std::string root_for_path (std::string const& path);
 	bool scm_enabled_for_path (std::string const& path);
 	info_ptr info (std::string path);
-	void wait_for_status (info_ptr info);
+	// Block until the SCM driver delivers a status callback for `info`,
+	// or until `timeout` seconds elapse. Returns true if a callback
+	// fired in time, false on timeout. The previous unbounded version
+	// could hang indefinitely when the callback never fired (intermittent
+	// FSEvents/runner-environment behaviour), exhausting the GitHub
+	// Actions step budget and cancelling the whole test job.
+	bool wait_for_status (info_ptr info, CFTimeInterval timeout = 30.0);
 
 } /* scm */
 

--- a/Frameworks/scm/tests/t_git.cc
+++ b/Frameworks/scm/tests/t_git.cc
@@ -15,7 +15,7 @@ struct setup_t
 		{
 			if(info = scm::info(jail.path()))
 			{
-				wait_for_status(info);
+				OAK_MASSERT("timed out waiting for git scm callback", scm::wait_for_status(info));
 			}
 			else
 			{

--- a/Frameworks/scm/tests/t_hg.cc
+++ b/Frameworks/scm/tests/t_hg.cc
@@ -19,7 +19,7 @@ void test_basic_status ()
 
 	if(auto info = scm::info(jail.path()))
 	{
-		wait_for_status(info);
+		OAK_MASSERT("timed out waiting for hg scm callback", scm::wait_for_status(info));
 
 		auto vars = info->scm_variables();
 		OAK_ASSERT_EQ(vars["TM_SCM_NAME"],   "hg");

--- a/Frameworks/scm/tests/t_scm.cc
+++ b/Frameworks/scm/tests/t_scm.cc
@@ -2,6 +2,7 @@
 #include <io/exec.h>
 #include <text/format.h>
 #include <test/jail.h>
+#include <chrono>
 
 void test_disabling_scm ()
 {
@@ -43,13 +44,52 @@ void test_two_repos_have_independent_queues ()
 	// race that window for info_b.
 	auto info_a = scm::info(jail_a.path());
 	OAK_ASSERT(info_a);
-	scm::wait_for_status(info_a);
+	OAK_ASSERT(scm::wait_for_status(info_a));
 
 	auto info_b = scm::info(jail_b.path());
 	OAK_ASSERT(info_b);
-	scm::wait_for_status(info_b);
+	OAK_ASSERT(scm::wait_for_status(info_b));
 
 	OAK_ASSERT_EQ(info_a->scm_variables()["TM_SCM_NAME"], "git");
 	OAK_ASSERT_EQ(info_b->scm_variables()["TM_SCM_NAME"], "git");
 	OAK_ASSERT_NE(info_a->root_path(), info_b->root_path());
+}
+
+// Regression guard for the unbounded-wait hang that cancelled PR #9 and
+// PR #17 merge CI runs at the 15-minute GitHub Actions step limit.
+// wait_for_status must return within its supplied timeout regardless
+// of whether a callback ever fires. The exact value returned (true or
+// false) depends on the race between the bootstrap commit's status
+// callback and the timeout; what we assert here is the bound itself.
+void test_wait_for_status_is_bounded ()
+{
+	static std::string const git = scm::find_executable("git", "TM_GIT");
+	if(git == NULL_STR)
+		return;
+
+	test::jail_t jail;
+	std::string const script = text::format(
+		"{ cd '%1$s' && '%2$s' init -b master "
+		"&& '%2$s' config user.email 'test@example.com' "
+		"&& '%2$s' config user.name 'Test Test' "
+		"&& '%2$s' config commit.gpgsign false "
+		"&& touch .dummy && '%2$s' add .dummy "
+		"&& '%2$s' commit .dummy -mGetHead ; } >/dev/null",
+		jail.path().c_str(), git.c_str());
+	io::exec("/bin/sh", "-c", script.c_str(), nullptr);
+
+	auto info = scm::info(jail.path());
+	OAK_ASSERT(info);
+
+	// 250 ms cap. The previous implementation could spin forever; this
+	// call must return promptly even if no callback arrives in window.
+	auto const start = std::chrono::steady_clock::now();
+	scm::wait_for_status(info, 0.25);
+	auto const elapsed_ms = std::chrono::duration_cast<std::chrono::milliseconds>(
+		std::chrono::steady_clock::now() - start).count();
+
+	// Generous upper bound: a single CFRunLoopRunInMode chunk plus
+	// scheduling slop. Anything in the seconds range means the bound
+	// is not being honoured.
+	OAK_ASSERT_LT(elapsed_ms, 2000);
 }

--- a/Frameworks/scm/tests/t_svn.cc
+++ b/Frameworks/scm/tests/t_svn.cc
@@ -22,7 +22,7 @@ void test_basic_status ()
 
 	if(auto info = scm::info(jail.path(wcName)))
 	{
-		wait_for_status(info);
+		OAK_MASSERT("timed out waiting for svn scm callback", scm::wait_for_status(info));
 
 		std::string expectedBranch = text::format("file://%s/%s", jailPath.c_str(), repoName.c_str());
 


### PR DESCRIPTION
## Problem

The scm tests' `wait_for_status` helper called `CFRunLoopRun()` with no timeout in a `while(shouldWait)` loop (`Frameworks/scm/src/scm.cc:438-452`). When the FSEvents/SCM callback failed to fire — intermittent on GitHub Actions `macos-26` runners — the test process hung forever and the workflow's 15-minute step killer was the only escape.

**Observed occurrences:**

| Run | PR | Result | scm-test stage |
|---|---|---|---|
| [27105282584](https://github.com/textmatelives/textmate/actions/runs/27105282584) | #17 merge | cancelled (15m20s) | hung at `[522/536] Run tests for 'scm'…` for 13m+; killed with `Terminate orphan process: pid (scm)` |
| [26555660272](https://github.com/textmatelives/textmate/actions/runs/26555660272) | #9 merge | cancelled (15m26s) | same pattern |

PR #17's **branch** CI ([27103954742](https://github.com/textmatelives/textmate/actions/runs/27103954742)) passed in 2m42s on byte-identical source (`git rev-parse 1bcec31c^{tree} == 03c3d5f3^{tree}`), confirming this is a flake of the wait helper, not a regression of the merged code.

## Fix

`wait_for_status` grows a `CFTimeInterval timeout` parameter (default 30s) and returns `bool` (`true` = callback fired, `false` = timeout). Implementation drives `CFRunLoopRunInMode` bounded by a deadline.

All 5 call sites assert the return so a timeout becomes a fast, useful failure naming the driver — instead of an orphan-PID kill 13 minutes later:

```c++
OAK_MASSERT("timed out waiting for git scm callback", scm::wait_for_status(info));
```

## Tests

New regression test `test_wait_for_status_is_bounded` asserts the bounded-time contract:

```c++
auto const start = std::chrono::steady_clock::now();
scm::wait_for_status(info, 0.25);   // 250 ms cap
auto const elapsed_ms = std::chrono::duration_cast<std::chrono::milliseconds>(
    std::chrono::steady_clock::now() - start).count();
OAK_ASSERT_LT(elapsed_ms, 2000);
```

## Local validation

- `ninja TextMate`: 78/78 OK, signed
- `ninja scm/test`: 82/84 pass; the 2 failures are pre-existing `hg`/`svn` skips for binaries not installed on the dev machine. Both are present on the GH Actions runner.
- New test runs in 107ms (under the 2000ms assert)

## Scope

No production callers exist — `wait_for_status` is test-only (5 call sites across 4 test files, verified by `grep -rn wait_for_status`).