### PR TITLE
themes: ship Undead, a Twilight-derived fork theme

### DIFF
--- a/Applications/TextMate/support/Bundles/Themes.tmbundle/Themes/Undead.tmTheme
+++ b/Applications/TextMate/support/Bundles/Themes.tmbundle/Themes/Undead.tmTheme
@@ -1,0 +1,597 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>author</key>
+    <string>dayglojesus (derived from Twilight by Michael Sheets)</string>
+    <key>gutterSettings</key>
+    <dict>
+      <key>background</key>
+      <string>#2F2F31</string>
+      <key>divider</key>
+      <string>#414143</string>
+      <key>foreground</key>
+      <string>#8F8F8F</string>
+      <key>selectionBackground</key>
+      <string>#414143</string>
+      <key>selectionBorder</key>
+      <string>#484848</string>
+      <key>selectionForeground</key>
+      <string>#BABABA</string>
+    </dict>
+    <key>name</key>
+    <string>Undead</string>
+    <key>semanticClass</key>
+    <string>theme.dark.undead</string>
+    <key>settings</key>
+    <array>
+      <dict>
+        <key>settings</key>
+        <dict>
+          <key>background</key>
+          <string>#151515</string>
+          <key>caret</key>
+          <string>#A7A7A7</string>
+          <key>foreground</key>
+          <string>#F8F8F8</string>
+          <key>invisibles</key>
+          <string>#FFFFFF40</string>
+          <key>lineHighlight</key>
+          <string>#FFFFFF08</string>
+          <key>selection</key>
+          <string>#DDF0FF33</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Foldings</string>
+        <key>scope</key>
+        <string>deco.folding</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#586C66</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Comment</string>
+        <key>scope</key>
+        <string>comment</string>
+        <key>settings</key>
+        <dict>
+          <key>fontStyle</key>
+          <string>italic</string>
+          <key>foreground</key>
+          <string>#605961</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Constant</string>
+        <key>scope</key>
+        <string>constant</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#E35F38</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Entity</string>
+        <key>scope</key>
+        <string>entity</string>
+        <key>settings</key>
+        <dict>
+          <key>fontStyle</key>
+          <string></string>
+          <key>foreground</key>
+          <string>#A97131</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Keyword</string>
+        <key>scope</key>
+        <string>keyword</string>
+        <key>settings</key>
+        <dict>
+          <key>fontStyle</key>
+          <string></string>
+          <key>foreground</key>
+          <string>#DCAC5A</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Storage</string>
+        <key>scope</key>
+        <string>storage</string>
+        <key>settings</key>
+        <dict>
+          <key>fontStyle</key>
+          <string></string>
+          <key>foreground</key>
+          <string>#FFF392</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>String</string>
+        <key>scope</key>
+        <string>string</string>
+        <key>settings</key>
+        <dict>
+          <key>fontStyle</key>
+          <string></string>
+          <key>foreground</key>
+          <string>#92A562</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Support</string>
+        <key>scope</key>
+        <string>support</string>
+        <key>settings</key>
+        <dict>
+          <key>fontStyle</key>
+          <string></string>
+          <key>foreground</key>
+          <string>#9E81A1</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Variable</string>
+        <key>scope</key>
+        <string>variable</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#6E85AD</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Invalid – Deprecated</string>
+        <key>scope</key>
+        <string>invalid.deprecated</string>
+        <key>settings</key>
+        <dict>
+          <key>fontStyle</key>
+          <string>italic underline</string>
+          <key>foreground</key>
+          <string>#D9A39A</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Invalid – Illegal</string>
+        <key>scope</key>
+        <string>invalid.illegal</string>
+        <key>settings</key>
+        <dict>
+          <key>background</key>
+          <string>#562D56BF</string>
+          <key>foreground</key>
+          <string>#F8F8F8</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>-----------------------------------</string>
+        <key>settings</key>
+        <dict/>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>♦ Embedded Source</string>
+        <key>scope</key>
+        <string>meta.embedded.block, punctuation.whitespace.embedded</string>
+        <key>settings</key>
+        <dict>
+          <key>background</key>
+          <string>#B0B3BA14</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>♦ Embedded Source (Bright)</string>
+        <key>scope</key>
+        <string>meta.embedded.line</string>
+        <key>settings</key>
+        <dict>
+          <key>background</key>
+          <string>#B1B3BA21</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>♦ Entity inherited-class</string>
+        <key>scope</key>
+        <string>entity.other.inherited-class</string>
+        <key>settings</key>
+        <dict>
+          <key>fontStyle</key>
+          <string>italic</string>
+          <key>foreground</key>
+          <string>#AB591E</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>♦ String embedded-source</string>
+        <key>scope</key>
+        <string>string meta.embedded</string>
+        <key>settings</key>
+        <dict>
+          <key>fontStyle</key>
+          <string></string>
+          <key>foreground</key>
+          <string>#DFFA98</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>♦ String constant</string>
+        <key>scope</key>
+        <string>string constant</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#E2FE98</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>♦ String.regexp</string>
+        <key>scope</key>
+        <string>string.regexp</string>
+        <key>settings</key>
+        <dict>
+          <key>fontStyle</key>
+          <string></string>
+          <key>foreground</key>
+          <string>#FDC84E</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>♦ String.regexp.«special»</string>
+        <key>scope</key>
+        <string>string.regexp constant.character.escape, string.regexp source.ruby.embedded, string.regexp string.regexp.arbitrary-repitition</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#E67C1D</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>♦ String variable</string>
+        <key>scope</key>
+        <string>string variable</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#889C96</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>♦ Support.function</string>
+        <key>scope</key>
+        <string>support.function</string>
+        <key>settings</key>
+        <dict>
+          <key>fontStyle</key>
+          <string></string>
+          <key>foreground</key>
+          <string>#E7DA78</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>♦ Support.constant</string>
+        <key>scope</key>
+        <string>support.constant</string>
+        <key>settings</key>
+        <dict>
+          <key>fontStyle</key>
+          <string></string>
+          <key>foreground</key>
+          <string>#E35F38</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>c C/C++ Preprocessor Line</string>
+        <key>scope</key>
+        <string>meta.preprocessor.c, source.swift meta.preprocessor</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#8495AD</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>c C/C++ Preprocessor Directive</string>
+        <key>scope</key>
+        <string>meta.preprocessor.c keyword, source.swift meta.preprocessor keyword</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#A8C4E2</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>✘ Doctype/XML Processing</string>
+        <key>scope</key>
+        <string>meta.tag.metadata.doctype, meta.tag.metadata.doctype entity, meta.tag.metadata.doctype string, meta.tag.metadata.processing.xml, meta.tag.metadata.processing.xml entity, meta.tag.metadata.processing.xml string</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#494949</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>✘ Meta.tag.«all»</string>
+        <key>scope</key>
+        <string>declaration.tag, declaration.tag entity, meta.tag, meta.tag entity</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#B8894F</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>✘ Meta.tag.inline</string>
+        <key>scope</key>
+        <string>declaration.tag.inline, declaration.tag.inline entity, meta.tag.inline, meta.tag.inline entity</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#EDCA7C</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>§ css tag-name</string>
+        <key>scope</key>
+        <string>meta.selector.css entity.name.tag</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#DCAC5A</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>§ css:pseudo-class</string>
+        <key>scope</key>
+        <string>meta.selector.css entity.other.attribute-name.tag.pseudo-class</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#92A562</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>§ css#id</string>
+        <key>scope</key>
+        <string>meta.selector.css entity.other.attribute-name.id</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#8697B0</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>§ css.class</string>
+        <key>scope</key>
+        <string>meta.selector.css entity.other.attribute-name.class</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#A97131</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>§ css property-name:</string>
+        <key>scope</key>
+        <string>support.type.property-name.css</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#D1B469</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>§ css property-value;</string>
+        <key>scope</key>
+        <string>meta.property-group support.constant.property-value.css, meta.property-value support.constant.property-value.css</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#FFF392</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>§ css @at-rule</string>
+        <key>scope</key>
+        <string>meta.preprocessor.at-rule keyword.control.at-rule</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#8192AA</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>§ css additional-constants</string>
+        <key>scope</key>
+        <string>meta.property-value support.constant.named-color.css, meta.property-value constant</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#DF742B</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>§ css constructor.argument</string>
+        <key>scope</key>
+        <string>meta.constructor.argument.css</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#92A562</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>⎇ diff.header</string>
+        <key>scope</key>
+        <string>meta.diff, meta.diff.header, meta.separator, meta.diff.range, meta.diff.index</string>
+        <key>settings</key>
+        <dict>
+          <key>background</key>
+          <string>#0E2231</string>
+          <key>fontStyle</key>
+          <string>italic</string>
+          <key>foreground</key>
+          <string>#F8F8F8</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>⎇ diff.deleted</string>
+        <key>scope</key>
+        <string>markup.deleted</string>
+        <key>settings</key>
+        <dict>
+          <key>background</key>
+          <string>#420E09</string>
+          <key>foreground</key>
+          <string>#F8F8F8</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>⎇ diff.changed</string>
+        <key>scope</key>
+        <string>markup.changed</string>
+        <key>settings</key>
+        <dict>
+          <key>background</key>
+          <string>#4A410D</string>
+          <key>foreground</key>
+          <string>#F8F8F8</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>⎇ diff.inserted</string>
+        <key>scope</key>
+        <string>markup.inserted</string>
+        <key>settings</key>
+        <dict>
+          <key>background</key>
+          <string>#253B22</string>
+          <key>foreground</key>
+          <string>#F8F8F8</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Markup: List</string>
+        <key>scope</key>
+        <string>markup.list</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#FFF392</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Markup: Heading</string>
+        <key>scope</key>
+        <string>markup.heading</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#E35F38</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Markup: Raw Block</string>
+        <key>scope</key>
+        <string>markup.raw.block</string>
+        <key>settings</key>
+        <dict>
+          <key>background</key>
+          <string>#B0B3BA14</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Test: 1</string>
+        <key>scope</key>
+        <string>meta.test1</string>
+        <key>settings</key>
+        <dict>
+          <key>background</key>
+          <string>#0E2231C5</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Test: 2</string>
+        <key>scope</key>
+        <string>meta.test2</string>
+        <key>settings</key>
+        <dict>
+          <key>background</key>
+          <string>#420E0990</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Test: 3</string>
+        <key>scope</key>
+        <string>meta.test3</string>
+        <key>settings</key>
+        <dict>
+          <key>background</key>
+          <string>#4A410D90</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>Test: 4</string>
+        <key>scope</key>
+        <string>meta.test4</string>
+        <key>settings</key>
+        <dict>
+          <key>background</key>
+          <string>#253B2290</string>
+        </dict>
+      </dict>
+    </array>
+    <key>uuid</key>
+    <string>B41A92B1-CF6D-4F7B-BABA-18600C5C193B</string>
+  </dict>
+</plist>


### PR DESCRIPTION
Adds **Undead**, a fork-local theme derived from upstream Twilight, to the bundled theme set so it shows up under View → Theme on a fresh install.

| | value |
|---|---|
| Name | Undead |
| UUID | `B41A92B1-CF6D-4F7B-BABA-18600C5C193B` |
| Bundle | Themes (UUID `A4380B27-F366-4C70-A542-B00D26ED997E`) |
| Base | Twilight (UUID `766026CB-703D-4610-B070-8DE07D967C5F`) |
| Background | \`#151515\` (Twilight: \`#181818\`) |
| Saturation | HSL S × 1.30 on every scope foreground; hue and lightness preserved |
| Untouched | selection, lineHighlight, caret, invisibles, gutterSettings, all scoped background tints |

One file added: \`Applications/TextMate/support/Bundles/Themes.tmbundle/Themes/Undead.tmTheme\`. Copied into the \`.app\` at build time by the existing \`default.rave:30\` rule.

Local verification:
- \`ninja TextMate\` builds + signs cleanly (no new warnings).
- Built \`.app\` contains \`Undead.tmTheme\` at \`Contents/SharedSupport/Bundles/Themes.tmbundle/Themes/\`.
- Upstream \`Twilight.tmTheme\` bg unchanged at \`#181818\`.