### PR TITLE
prefs: SF Symbols for the preferences toolbar icons

### DIFF
--- a/Frameworks/Preferences/src/BundlesPreferences.mm
+++ b/Frameworks/Preferences/src/BundlesPreferences.mm
@@ -217,7 +217,12 @@ static NSUserInterfaceItemIdentifier const kTableColumnIdentifierActions     = @
 @end
 
 @implementation BundlesPreferences
-- (NSImage*)toolbarItemImage { return [NSWorkspace.sharedWorkspace iconForFileType:@"tmbundle"]; }
+- (NSImage*)toolbarItemImage
+{
+	if(@available(macos 11.0, *))
+		return [NSImage imageWithSystemSymbolName:@"puzzlepiece.extension" accessibilityDescription:@"Bundles"];
+	return [NSWorkspace.sharedWorkspace iconForFileType:@"tmbundle"];
+}
 
 - (id)init
 {

--- a/Frameworks/Preferences/src/FilesPreferences.mm
+++ b/Frameworks/Preferences/src/FilesPreferences.mm
@@ -14,7 +14,10 @@
 @implementation FilesPreferences
 - (id)init
 {
-	if(self = [super initWithNibName:nil label:@"Files" image:[NSImage imageNamed:NSImageNameMultipleDocuments]])
+	NSImage* icon = [NSImage imageNamed:NSImageNameMultipleDocuments];
+	if(@available(macos 11.0, *))
+		icon = [NSImage imageWithSystemSymbolName:@"doc.on.doc" accessibilityDescription:@"Files"];
+	if(self = [super initWithNibName:nil label:@"Files" image:icon])
 	{
 		[OakStringListTransformer createTransformerWithName:@"OakLineEndingsSettingsTransformer" andObjectsArray:@[ @"\\n", @"\\r", @"\\r\\n" ]];
 

--- a/Frameworks/Preferences/src/Preferences.mm
+++ b/Frameworks/Preferences/src/Preferences.mm
@@ -183,7 +183,29 @@ static NSString* const kMASPreferencesSelectedViewKey = @"MASPreferences Selecte
 	{
 		res.label = viewController.title;
 		if([viewController respondsToSelector:@selector(toolbarItemImage)])
-			res.image = viewController.toolbarItemImage;
+		{
+			NSImage* image = viewController.toolbarItemImage;
+			// SF Symbol panes render a larger glyph via scale (keeps the box compact); PNG
+			// fallbacks return nil here and are left as-is.
+			if(@available(macos 11.0, *))
+			{
+				if(NSImage* symbol = [image imageWithSymbolConfiguration:[NSImageSymbolConfiguration configurationWithScale:NSImageSymbolScaleLarge]])
+				{
+					// The preference toolbar positions the label off the bottom of the icon's
+					// box, so pad the box below the glyph to widen the icon→label gap without
+					// changing the glyph size. Kept as a template image so it still tints.
+					CGFloat const kLabelGapPadding = 6;
+					NSSize const glyphSize = symbol.size;
+					NSImage* padded = [NSImage imageWithSize:NSMakeSize(glyphSize.width, glyphSize.height + kLabelGapPadding) flipped:NO drawingHandler:^BOOL(NSRect){
+						[symbol drawInRect:NSMakeRect(0, kLabelGapPadding, glyphSize.width, glyphSize.height)];
+						return YES;
+					}];
+					[padded setTemplate:YES];
+					image = padded;
+				}
+			}
+			res.image = image;
+		}
 	}
 
 	return res;

--- a/Frameworks/Preferences/src/ProjectsPreferences.mm
+++ b/Frameworks/Preferences/src/ProjectsPreferences.mm
@@ -17,7 +17,10 @@
 @implementation ProjectsPreferences
 - (id)init
 {
-	if(self = [super initWithNibName:nil label:@"Projects" image:[NSImage imageNamed:@"Projects" inSameBundleAsClass:[self class]]])
+	NSImage* icon = [NSImage imageNamed:@"Projects" inSameBundleAsClass:[self class]];
+	if(@available(macos 11.0, *))
+		icon = [NSImage imageWithSystemSymbolName:@"folder" accessibilityDescription:@"Projects"];
+	if(self = [super initWithNibName:nil label:@"Projects" image:icon])
 	{
 		[OakStringListTransformer createTransformerWithName:@"OakFileBrowserPlacementSettingsTransformer" andObjectsArray:@[ @"left", @"right" ]];
 		[OakStringListTransformer createTransformerWithName:@"OakHTMLOutputPlacementSettingsTransformer" andObjectsArray:@[ @"bottom", @"right", @"window" ]];

--- a/Frameworks/Preferences/src/SoftwareUpdatePreferences.mm
+++ b/Frameworks/Preferences/src/SoftwareUpdatePreferences.mm
@@ -19,7 +19,10 @@
 
 - (id)init
 {
-	if(self = [super initWithNibName:nil label:@"Software Update" image:[NSImage imageNamed:@"Software Update" inSameBundleAsClass:[self class]]])
+	NSImage* icon = [NSImage imageNamed:@"Software Update" inSameBundleAsClass:[self class]];
+	if(@available(macos 11.0, *))
+		icon = [NSImage imageWithSystemSymbolName:@"arrow.triangle.2.circlepath" accessibilityDescription:@"Software Update"];
+	if(self = [super initWithNibName:nil label:@"Software Update" image:icon])
 	{
 		// Single release stream for now; prerelease reinstated with a beta stream (see WISHLIST.md).
 		[OakStringListTransformer createTransformerWithName:@"OakSoftwareUpdateChannelTransformer" andObjectsArray:@[ kSoftwareUpdateChannelRelease ]];

--- a/Frameworks/Preferences/src/TerminalPreferences.mm
+++ b/Frameworks/Preferences/src/TerminalPreferences.mm
@@ -153,7 +153,10 @@ static bool uninstall_mate (std::string const& path)
 @implementation TerminalPreferences
 - (id)init
 {
-	if(self = [super initWithNibName:@"TerminalPreferences" label:@"Terminal" image:[NSImage imageNamed:@"Terminal" inSameBundleAsClass:[self class]]])
+	NSImage* icon = [NSImage imageNamed:@"Terminal" inSameBundleAsClass:[self class]];
+	if(@available(macos 11.0, *))
+		icon = [NSImage imageWithSystemSymbolName:@"terminal" accessibilityDescription:@"Terminal"];
+	if(self = [super initWithNibName:@"TerminalPreferences" label:@"Terminal" image:icon])
 	{
 		[OakStringListTransformer createTransformerWithName:@"OakRMateInterfaceTransformer" andObjectsArray:@[ kRMateServerListenLocalhost, kRMateServerListenRemote ]];
 

--- a/Frameworks/Preferences/src/VariablesPreferences.mm
+++ b/Frameworks/Preferences/src/VariablesPreferences.mm
@@ -17,7 +17,12 @@ static NSString* const kVariableKeyValue   = @"value";
 @end
 
 @implementation VariablesPreferences
-- (NSImage*)toolbarItemImage { return [NSImage imageNamed:@"Variables" inSameBundleAsClass:[self class]]; }
+- (NSImage*)toolbarItemImage
+{
+	if(@available(macos 11.0, *))
+		return [NSImage imageWithSystemSymbolName:@"dollarsign.circle" accessibilityDescription:@"Variables"];
+	return [NSImage imageNamed:@"Variables" inSameBundleAsClass:[self class]];
+}
 
 - (id)init
 {


### PR DESCRIPTION
## What

Replaces the preference toolbar's mixed icon sources with a unified set of SF Symbols, so the row reads as one cohesive, theme-aware toolbar instead of a mix of a flat stock glyph, a glossy green $, a blue globe, and a file-type 'LEGO box'.

| Pane | Was | Now (SF Symbol) |
|------|-----|-----------------|
| Files | `NSImageNameMultipleDocuments` (stock) | `doc.on.doc` |
| Projects | `Projects.png` | `folder` |
| Bundles | `iconForFileType:@"tmbundle"` | `puzzlepiece.extension` |
| Variables | `Variables.png` | `dollarsign.circle` |
| Software Update | `Software Update.png` | `arrow.triangle.2.circlepath` |
| Terminal | `Terminal.png` | `terminal` |

## How

- Each pane resolves its SF Symbol behind `if(@available(macos 11.0, *))` and falls back to its previous icon on older systems. Deployment target is **10.12** (`default.rave:1`); SF Symbols need macOS 11. The four PNGs under `Frameworks/Preferences/icons/` are kept for that fallback.
- Sizing/spacing is handled once at the toolbar chokepoint (`Preferences.mm`): the symbol gets a `scale .large` configuration (larger glyph, compact box) plus a transparent bottom-padding pass so the icon→label gap matches the `NSWindowToolbarStylePreference` style. The padded image stays a template image so the selected item still tints blue. Non-symbol fallbacks return `nil` from the config call and pass through untouched.

## Verification

- All six symbol names verified to resolve on the build host before wiring.
- `ninja TextMate` builds clean (42/42), links, and signs.
- Launched locally; toolbar renders the unified set with correct selected-item tint and label spacing.

## Notes

The `puzzlepiece.extension` (Bundles) and `dollarsign.circle` (Variables) picks are the two judgment calls; `shippingbox` and `curlybraces` are alternatives if preferred.