### PR TITLE
Add TextMate::Gems shared gem store for bundles

### DIFF
--- a/Applications/TextMate/support/Bundles/Bundle Support.tmbundle/Support/shared/lib/tm/gems.rb
+++ b/Applications/TextMate/support/Bundles/Bundle Support.tmbundle/Support/shared/lib/tm/gems.rb
@@ -1,0 +1,116 @@
+# encoding: utf-8
+#
+# TextMate::Gems — a shared RubyGems store for bundle commands.
+#
+# A bundle declares its dependencies in $TM_BUNDLE_SUPPORT/Gemfile and calls:
+#
+#     require "#{ENV['TM_SUPPORT_PATH']}/lib/tm/gems"
+#     TextMate::Gems.setup(name: "Markdown (GitHub)")
+#     require "redcarpet"   # resolvable from the shared store
+#
+# Gems install once into a shared, ABI-keyed store and are reused by every
+# bundle that lists them, so the same gem+version is never vendored twice.
+#
+# Install is silent on success. On failure the user sees one concise native
+# alert (no stacktrace); the full failure — command, exit status, output and
+# backtrace — is written to <store>/install.log.
+
+require "fileutils"
+require "rbconfig"
+require "time"
+
+module TextMate
+  module Gems
+    class Error < StandardError; end
+
+    module_function
+
+    # Root of the shared store. Keyed by Ruby ABI so a native gem built for one
+    # Ruby never loads into another. Override the base with TM_GEMS_DIR (tests).
+    def store
+      base = ENV["TM_GEMS_DIR"] || File.expand_path("~/Library/Application Support/TextMate/Gems")
+      File.join(base, Gem.ruby_api_version)
+    end
+
+    def log_path
+      File.join(store, "install.log")
+    end
+
+    # Ensure the bundle's locked dependencies are present and activated.
+    # Silent on success; presents an alert and aborts on failure.
+    def setup(name: ENV["TM_BUNDLE_NAME"] || "TextMate", gemfile: default_gemfile)
+      prepare(gemfile)
+    rescue => e
+      fail!(e, name)
+    end
+
+    # Activate the Gemfile from the shared store, installing it first if needed.
+    # Raises on any failure (used directly by tests).
+    def prepare(gemfile = default_gemfile)
+      raise Error, "no Gemfile at #{gemfile}" unless File.file?(gemfile)
+
+      FileUtils.mkdir_p(store)
+      ENV["BUNDLE_GEMFILE"] = gemfile
+      ENV["BUNDLE_PATH"]    = store
+
+      require "bundler"
+      begin
+        Bundler.setup
+      rescue Bundler::BundlerError, LoadError
+        install!(gemfile)
+        Bundler.reset! if Bundler.respond_to?(:reset!)
+        Bundler.setup
+      end
+      true
+    end
+
+    # Run `bundle install` into the shared store with the running interpreter,
+    # capturing all output. Raises Error with the captured output on failure.
+    def install!(gemfile)
+      cmd = [Gem.ruby, bundle_bin, "install"]
+      output = IO.popen(cmd, err: [:child, :out]) { |io| io.read }
+      status = $?
+      return if status.success?
+      raise Error, "`bundle install` exited #{status.exitstatus}\n$ #{cmd.join(' ')}\n#{output}"
+    end
+
+    def default_gemfile
+      File.join(ENV["TM_BUNDLE_SUPPORT"].to_s, "Gemfile")
+    end
+
+    # The bundle executable that ships with the running Ruby.
+    def bundle_bin
+      candidate = File.join(RbConfig::CONFIG["bindir"], "bundle")
+      File.exist?(candidate) ? candidate : Gem.bin_path("bundler", "bundle")
+    end
+
+    # Log full detail, show one concise native alert, then abort. No stacktrace
+    # reaches the user.
+    def fail!(error, name)
+      write_log(error)
+      message = "Couldn't install the dependencies for #{name}. See #{log_path}"
+      alert(name, message)
+      exit 1
+    end
+
+    def write_log(error)
+      FileUtils.mkdir_p(store)
+      File.open(log_path, "a") do |f|
+        f.puts "[#{Time.now.iso8601 rescue Time.now}] #{error.class}: #{error.message}"
+        f.puts error.backtrace.join("\n") if error.backtrace
+        f.puts
+      end
+    rescue
+      # logging must never mask the original failure
+    end
+
+    # Native $DIALOG alert (yellow-triangle), matching the app's own bundle
+    # errors. Falls back to stderr when the dialog tool is unavailable.
+    def alert(title, message)
+      require "#{ENV['TM_SUPPORT_PATH']}/lib/ui"
+      TextMate::UI.alert(:warning, title, message, "OK")
+    rescue
+      warn message
+    end
+  end
+end

--- a/Applications/TextMate/support/Bundles/Bundle Support.tmbundle/Support/shared/lib/tm/gems_test.rb
+++ b/Applications/TextMate/support/Bundles/Bundle Support.tmbundle/Support/shared/lib/tm/gems_test.rb
@@ -1,0 +1,63 @@
+# encoding: utf-8
+#
+# Unit tests for TextMate::Gems that need no network. The full install / dedup /
+# render path is exercised by the GitHub-Markdown bundle integration runs.
+#
+#   ruby gems_test.rb
+
+require "minitest/autorun"
+require "fileutils"
+require_relative "gems"
+
+class GemsTest < Minitest::Test
+  def setup
+    @tmp = File.join(Dir.tmpdir, "tm-gems-test-#{$$}")
+    FileUtils.mkdir_p(@tmp)
+    ENV["TM_GEMS_DIR"] = @tmp
+  end
+
+  def teardown
+    FileUtils.rm_rf(@tmp)
+    ENV.delete("TM_GEMS_DIR")
+  end
+
+  def test_store_is_keyed_by_ruby_abi_under_the_override
+    assert_equal File.join(@tmp, Gem.ruby_api_version), TextMate::Gems.store
+  end
+
+  def test_default_gemfile_is_under_the_bundle_support_dir
+    ENV["TM_BUNDLE_SUPPORT"] = "/some/bundle/Support"
+    assert_equal "/some/bundle/Support/Gemfile", TextMate::Gems.default_gemfile
+  ensure
+    ENV.delete("TM_BUNDLE_SUPPORT")
+  end
+
+  def test_bundle_bin_resolves_to_an_existing_executable
+    assert File.exist?(TextMate::Gems.bundle_bin), "expected a bundle binary on disk"
+  end
+
+  def test_prepare_raises_when_the_gemfile_is_missing
+    err = assert_raises(TextMate::Gems::Error) do
+      TextMate::Gems.prepare(File.join(@tmp, "does-not-exist", "Gemfile"))
+    end
+    assert_match(/no Gemfile/, err.message)
+  end
+
+  def test_write_log_records_class_message_and_backtrace
+    error = TextMate::Gems::Error.new("boom")
+    error.set_backtrace(["frame-one", "frame-two"])
+    TextMate::Gems.write_log(error)
+
+    log = File.read(TextMate::Gems.log_path)
+    assert_match(/TextMate::Gems::Error: boom/, log)
+    assert_match(/frame-one/, log)
+    assert_match(/frame-two/, log)
+  end
+
+  def test_write_log_appends_rather_than_truncates
+    2.times { |i| TextMate::Gems.write_log(TextMate::Gems::Error.new("err-#{i}")) }
+    log = File.read(TextMate::Gems.log_path)
+    assert_match(/err-0/, log)
+    assert_match(/err-1/, log)
+  end
+end


### PR DESCRIPTION
Introduces a shared RubyGems store so bundles can declare dependencies in a `Support/Gemfile` and have them installed **once** into a common, ABI-keyed location — instead of trusting the system `GEM_PATH` or vendoring duplicate copies per bundle.

## `shared/lib/tm/gems.rb`
`TextMate::Gems.setup(name:, gemfile:)`:
- Resolves the calling bundle's `Support/Gemfile` from one shared store at
  `~/Library/Application Support/TextMate/Gems/<ruby_api_version>` (override via `TM_GEMS_DIR`).
- **Dedup:** a gem+version is installed once and reused by every bundle that lists it.
- **Silent** on the happy path — installs via `bundle install` with no window.
- **On failure:** one concise native alert (`TextMate::UI.alert`, no stacktrace); the full failing command, output, and backtrace go to `<store>/install.log`. Never falls back silently to system gems.

ABI keying is required because native extensions are compiled per Ruby version/arch; pure-Ruby gems share across everything.

## `shared/lib/tm/gems_test.rb`
Unit tests for the no-network logic — store keying, default Gemfile path, bundle-binary resolution, missing-Gemfile error, and log contents/append behaviour. `6 runs, 16 assertions, 0 failures`.

## Verified
Exercised end-to-end against a real consumer (the GitHub-Markdown bundle, separate PR): clean store → silent install → render; second run no-network; a second bundle shares the single gem copy; unresolvable Gemfile → exit 1, empty stdout, detail logged.

## First consumer
`textmatelives/GitHub-Markdown.tmbundle` (companion PR) uses this to drop redcarpet + Rouge in place of the Python `pygments` dependency. That bundle's command requires `$TM_SUPPORT_PATH/lib/tm/gems`, so **this PR should land first**.

Design notes: `DESIGN-shared-gems.md` (workshop).