### PR TITLE
Warm a bundle's gems when it is installed, not on first use

### DIFF
--- a/Applications/TextMate/support/Bundles/Bundle Support.tmbundle/Support/shared/lib/tm/gems.rb
+++ b/Applications/TextMate/support/Bundles/Bundle Support.tmbundle/Support/shared/lib/tm/gems.rb
@@ -44,6 +44,18 @@ module TextMate
       fail!(e, name)
     end
 
+    # Warm the store ahead of first use: install a bundle's dependencies
+    # without alerting or aborting. Called by the post-install hook when a
+    # bundle ships a Gemfile. Logs on failure and returns false; the lazy
+    # setup path surfaces any problem at actual use time.
+    def preinstall(gemfile = default_gemfile)
+      prepare(gemfile)
+      true
+    rescue => e
+      write_log(e)
+      false
+    end
+
     # Activate the Gemfile from the shared store, installing it first if needed.
     # Raises on any failure (used directly by tests).
     def prepare(gemfile = default_gemfile)

--- a/Applications/TextMate/support/Bundles/Bundle Support.tmbundle/Support/shared/lib/tm/gems_test.rb
+++ b/Applications/TextMate/support/Bundles/Bundle Support.tmbundle/Support/shared/lib/tm/gems_test.rb
@@ -54,6 +54,11 @@ class GemsTest < Minitest::Test
     assert_match(/frame-two/, log)
   end
 
+  def test_preinstall_returns_false_and_logs_on_missing_gemfile
+    refute TextMate::Gems.preinstall(File.join(@tmp, "nope", "Gemfile"))
+    assert_match(/no Gemfile/, File.read(TextMate::Gems.log_path))
+  end
+
   def test_write_log_appends_rather_than_truncates
     2.times { |i| TextMate::Gems.write_log(TextMate::Gems::Error.new("err-#{i}")) }
     log = File.read(TextMate::Gems.log_path)

--- a/Frameworks/BundlesManager/src/BundlesManager.mm
+++ b/Frameworks/BundlesManager/src/BundlesManager.mm
@@ -544,6 +544,39 @@ static NSString* SafeBasename (NSString* name)
 	return NO;
 }
 
+// After a bundle is installed or updated, warm its RubyGems dependencies (when
+// it ships Support/Gemfile) into TextMate's shared gem store, so the first
+// command that needs them does not pay the install cost. Asynchronous and
+// non-blocking: tm/gems logs any failure to the store's install.log and the
+// lazy setup path surfaces it at actual use time, so nothing here alerts.
+static void WarmBundleGems (NSString* bundlePath)
+{
+	NSString* gemfile = [bundlePath stringByAppendingPathComponent:@"Support/Gemfile"];
+	if(![NSFileManager.defaultManager fileExistsAtPath:gemfile])
+		return;
+
+	// Use the embedded shared support so tm/gems always matches this binary
+	// (a Managed copy can lag). The gem store path is independent of this.
+	NSString* supportPath = [NSBundle.mainBundle.sharedSupportPath stringByAppendingPathComponent:@"Bundles/Bundle Support.tmbundle/Support/shared"];
+
+	NSTask* task = [NSTask new];
+	task.launchPath = @"/usr/bin/ruby";
+	task.arguments  = @[ @"-e", @"require \"#{ENV['TM_SUPPORT_PATH']}/lib/tm/gems\"; TextMate::Gems.preinstall(ARGV[0])", gemfile ];
+	NSMutableDictionary* env = [NSProcessInfo.processInfo.environment mutableCopy];
+	env[@"TM_SUPPORT_PATH"] = supportPath;
+	task.environment = env;
+	task.terminationHandler = ^(NSTask* t){
+		if(t.terminationStatus != 0)
+			os_log_error(OS_LOG_DEFAULT, "WarmBundleGems: ruby exited %d for %{public}@", t.terminationStatus, bundlePath);
+	};
+	@try {
+		[task launch];
+	}
+	@catch(NSException* e) {
+		os_log_error(OS_LOG_DEFAULT, "WarmBundleGems: launch failed: %{public}@", e.reason);
+	}
+}
+
 - (NSProgress*)installBundles:(NSArray<Bundle*>*)someBundles completionHandler:(void(^)(NSArray<Bundle*>*))callback
 {
 	if(someBundles.count == 0)
@@ -592,6 +625,7 @@ static NSString* SafeBasename (NSString* name)
 				bundle.lastUpdated = spec.installedAt;
 				[self reloadPath:destURL.path recursive:YES];
 				[installed addObject:bundle];
+				WarmBundleGems(destURL.path);
 			}
 			dispatch_group_leave(group);
 		}];
@@ -659,6 +693,7 @@ static NSString* SafeBasename (NSString* name)
 				path::set_attr(destURL.path.fileSystemRepresentation, kBundleAttributeUpdated, to_s(resolvedSHA ?: @""));
 				[self reloadPath:destURL.path recursive:YES];
 				[installed addObject:registered];
+				WarmBundleGems(destURL.path);
 			}
 			dispatch_group_leave(group);
 		}];


### PR DESCRIPTION
Follow-up to the shared gem store. A bundle with a `Support/Gemfile` previously installed its gems **lazily** — on the first command that needed them. For the GitHub-Markdown preview that meant the first preview blocked while `bundle install` ran, and the HTMLOutput window didn't open until it finished (looked like a hang; observed in testing).

This moves the install to **bundle-install/update time** so the store is warm before first use.

## Change
- **`BundlesManager.mm`** — after a bundle is installed via `installBundles:` or `installSpecs:`, `WarmBundleGems` checks for `Support/Gemfile` and, if present, spawns `ruby … TextMate::Gems.preinstall(<Gemfile>)` **asynchronously** (NSTask + terminationHandler, non-blocking). It uses the **embedded** Bundle Support so `tm/gems` always matches this binary (a Managed copy can lag). Failures go to `os_log` and the store's `install.log`; nothing alerts here.
- **`tm/gems.rb`** — new `TextMate::Gems.preinstall`: install + log on failure, but never alert or abort (the alert belongs to the user-triggered command path).
- **`gems_test.rb`** — covers `preinstall`'s missing-Gemfile path.

The lazy `setup` in consumer commands (e.g. `redcarpet.rb`) is unchanged and becomes an instant no-op once warm — so it remains the safety net if a bundle is hand-dropped.

## Verified
- 7/7 unit tests green.
- Headless: the exact command the hook runs (`TextMate::Gems.preinstall(<GitHub-Markdown Gemfile>)`) warms a cold store to redcarpet + rouge with **no preview** involved.
- Builds clean (`ninja TextMate`).

## Pending in-app confirmation
The hook fires when a Gemfile-bearing bundle is installed/enabled. To confirm end-to-end: with a cold store, enable **Markdown (GitHub)** in Preferences → Bundles; the gem store should repopulate in the background within ~15s without opening a preview.