### PR TITLE
Make GitHub-Markdown a default bundle

### DIFF
--- a/Applications/TextMate/support/Bundles/Bundle Support.tmbundle/Support/AvailableBundles.plist
+++ b/Applications/TextMate/support/Bundles/Bundle Support.tmbundle/Support/AvailableBundles.plist
@@ -421,15 +421,6 @@
 			<key>description</key><string>Syntax highlight for man pages (http://en.wikipedia.org/wiki/Manual_page_(Unix)) and a few commands.</string>
 </dict>
 <dict>
-	<key>uuid</key><string>A9CF0E77-E848-417C-90F4-77E1231FF1B9</string>
-	<key>name</key><string>Markdown (GitHub)</string>
-	<key>url</key><string>https://github.com/textmatelives/GitHub-Markdown.tmbundle</string>
-	<key>ref</key><string>main</string>
-	<key>autoUpdate</key><true/>
-	<key>category</key><string>Languages</string>
-			<key>description</key><string>GFM syntax highlighting and preview.</string>
-</dict>
-<dict>
 	<key>uuid</key><string>D2B42D16-FDEB-4079-9293-725312736384</string>
 	<key>name</key><string>Mathematica</string>
 	<key>url</key><string>https://github.com/textmatelives/mathematica-tmbundle</string>

--- a/Applications/TextMate/support/Bundles/Bundle Support.tmbundle/Support/DefaultBundles.plist
+++ b/Applications/TextMate/support/Bundles/Bundle Support.tmbundle/Support/DefaultBundles.plist
@@ -328,6 +328,22 @@
 			<key>autoUpdate</key>
 			<true/>
 			<key>category</key>
+			<string>Languages</string>
+			<key>description</key>
+			<string>GFM syntax highlighting and preview.</string>
+			<key>name</key>
+			<string>Markdown (GitHub)</string>
+			<key>ref</key>
+			<string>main</string>
+			<key>url</key>
+			<string>https://github.com/textmatelives/GitHub-Markdown.tmbundle</string>
+			<key>uuid</key>
+			<string>A9CF0E77-E848-417C-90F4-77E1231FF1B9</string>
+		</dict>
+		<dict>
+			<key>autoUpdate</key>
+			<true/>
+			<key>category</key>
 			<string>Other</string>
 			<key>description</key>
 			<string>Support for performing different calculations inside TextMate.</string>


### PR DESCRIPTION
Promote the **Markdown (GitHub)** bundle from opt-in to default.

## Change
- Move the `Markdown (GitHub)` catalogue entry from `AvailableBundles.plist` (opt-in) to `DefaultBundles.plist` (auto-install).
- Entry is otherwise unchanged: same uuid, url, ref (`main`), `autoUpdate`, category, and description.
- Placed directly after the base `Markdown` entry.

## Effect
A fresh install now gets GFM syntax highlighting and preview out of the box. The warm-on-install hook (#22) installs the bundle's gems (redcarpet, rouge) at install time, so the first preview is ready without a cold lazy install.

## Note
This means a default bootstrap now performs a network + native-extension compile step (redcarpet is a C extension) for this bundle. That is the intended consequence of shipping it by default.

The companion `Markdown (GitHub) Font Settings` theme bundle is left opt-in in `AvailableBundles.plist`.

## Verification
- Both plists pass `plutil -lint`.
- The entry appears exactly once in `DefaultBundles.plist` and is absent from `AvailableBundles.plist`.