### PR TITLE
Implement the prerelease (beta) software-update channel

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -294,7 +294,16 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           VERSION: ${{ steps.version.outputs.version }}
         run: |
+          set -euo pipefail
+          # -beta versions publish as GitHub prereleases: excluded from
+          # releases/latest (the stable update feed), picked up by the beta
+          # channel's list endpoint.
+          PRERELEASE_FLAG=""
+          case "${VERSION}" in
+            *-beta*) PRERELEASE_FLAG="--prerelease" ;;
+          esac
           gh release create "v${VERSION}" \
+            ${PRERELEASE_FLAG} \
             --target "${GITHUB_SHA}" \
             --title "TextMate ${VERSION}" \
             --notes-file "${{ steps.notes.outputs.notes_file }}" \

--- a/Applications/TextMate/src/AppController.mm
+++ b/Applications/TextMate/src/AppController.mm
@@ -488,14 +488,17 @@ BOOL HasDocumentWindow (NSArray* windows)
 
 	// Fork update feed: the GitHub Releases API for textmatelives/textmate.
 	// SoftwareUpdate adapts the API's JSON (tag_name + .tbz asset) into the
-	// { url, version } shape it expects. The fork publishes a single release
-	// stream, so all channels point at the same endpoint; the prefs UI only
-	// exposes "Normal releases" anyway.
-	NSString* const feedURL = @"https://api.github.com/repos/textmatelives/textmate/releases/latest";
+	// { url, version } shape it expects. Release uses releases/latest, which
+	// excludes prereleases; the beta channel lists all releases and picks the
+	// highest version, prerelease or not, so beta users converge back onto
+	// stable when it catches up. No nightly stream exists, so Canary stays on
+	// the stable endpoint.
+	NSString* const stableFeedURL = @"https://api.github.com/repos/textmatelives/textmate/releases/latest";
+	NSString* const betaFeedURL   = @"https://api.github.com/repos/textmatelives/textmate/releases?per_page=20";
 	SoftwareUpdate.sharedInstance.channels = @{
-		kSoftwareUpdateChannelRelease:    [NSURL URLWithString:feedURL],
-		kSoftwareUpdateChannelPrerelease: [NSURL URLWithString:feedURL],
-		kSoftwareUpdateChannelCanary:     [NSURL URLWithString:feedURL],
+		kSoftwareUpdateChannelRelease:    [NSURL URLWithString:stableFeedURL],
+		kSoftwareUpdateChannelPrerelease: [NSURL URLWithString:betaFeedURL],
+		kSoftwareUpdateChannelCanary:     [NSURL URLWithString:stableFeedURL],
 	};
 
 	settings_t::set_default_settings_path([[[NSBundle mainBundle] pathForResource:@"Default" ofType:@"tmProperties"] fileSystemRepresentation]);

--- a/Frameworks/Preferences/src/SoftwareUpdatePreferences.mm
+++ b/Frameworks/Preferences/src/SoftwareUpdatePreferences.mm
@@ -24,8 +24,7 @@
 		icon = [NSImage imageWithSystemSymbolName:@"arrow.triangle.2.circlepath" accessibilityDescription:@"Software Update"];
 	if(self = [super initWithNibName:nil label:@"Software Update" image:icon])
 	{
-		// Single release stream for now; prerelease reinstated with a beta stream (see WISHLIST.md).
-		[OakStringListTransformer createTransformerWithName:@"OakSoftwareUpdateChannelTransformer" andObjectsArray:@[ kSoftwareUpdateChannelRelease ]];
+		[OakStringListTransformer createTransformerWithName:@"OakSoftwareUpdateChannelTransformer" andObjectsArray:@[ kSoftwareUpdateChannelRelease, kSoftwareUpdateChannelPrerelease ]];
 	}
 	return self;
 }
@@ -129,6 +128,7 @@
 
 	MBMenu const updateChannelMenuItems = {
 		{ @"Normal releases", .tag = 0 },
+		{ @"Prereleases",     .tag = 1 },
 	};
 	MBCreateMenu(updateChannelMenuItems, updateChannelPopUp.menu);
 

--- a/Frameworks/SoftwareUpdate/src/SoftwareUpdate.h
+++ b/Frameworks/SoftwareUpdate/src/SoftwareUpdate.h
@@ -18,3 +18,8 @@ extern NSString* const kSoftwareUpdateChannelCanary;
 @end
 
 NSComparisonResult OakCompareVersionStrings (NSString* lhsString, NSString* rhsString);
+
+// Given a GitHub “list releases” response, returns the release with the
+// highest version (per OakCompareVersionStrings on tag_name), skipping drafts
+// and — unless includePrereleases — prereleases. Returns nil if none qualify.
+NSDictionary* OakSelectGitHubRelease (NSArray* releases, BOOL includePrereleases);

--- a/Frameworks/SoftwareUpdate/src/SoftwareUpdate.mm
+++ b/Frameworks/SoftwareUpdate/src/SoftwareUpdate.mm
@@ -46,6 +46,35 @@ static void OakExtractUpdateInfo (NSDictionary* dict, NSURL** outURL, NSString**
 	}
 }
 
+NSDictionary* OakSelectGitHubRelease (NSArray* releases, BOOL includePrereleases)
+{
+	NSDictionary* best = nil;
+	NSString* bestVersion = nil;
+
+	for(NSDictionary* release in releases)
+	{
+		if(![release isKindOfClass:NSDictionary.class] || [release[@"draft"] boolValue])
+			continue;
+		if(!includePrereleases && [release[@"prerelease"] boolValue])
+			continue;
+
+		NSString* tag = release[@"tag_name"];
+		if(![tag isKindOfClass:NSString.class])
+			continue;
+
+		// The list is ordered by creation date, not version, so compare
+		// explicitly (a hotfix can be published after a newer beta).
+		NSString* version = [tag hasPrefix:@"v"] ? [tag substringFromIndex:1] : tag;
+		if(!best || OakCompareVersionStrings(bestVersion, version) == NSOrderedAscending)
+		{
+			best        = release;
+			bestVersion = version;
+		}
+	}
+
+	return best;
+}
+
 // Team Identifier of the currently running application, or nil if unsigned /
 // ad-hoc signed (e.g. a local development build).
 static NSString* OakRunningApplicationTeamIdentifier ()
@@ -227,10 +256,16 @@ static BOOL OakBundleIsSignedByTeam (NSURL* appURL, NSString* expectedTeamID)
 			{
 				if(NSString* contentType = ((NSHTTPURLResponse*)response).allHeaderFields[@"Content-Type"])
 				{
-					NSDictionary* plist;
+					id plist;
 					if([contentType hasPrefix:@"application/json"]) // GitHub sends "application/json; charset=utf-8"
 							plist = [NSJSONSerialization JSONObjectWithData:data options:0 error:nullptr];
 					else	plist = [NSPropertyListSerialization propertyListWithData:data options:NSPropertyListImmutable format:nil error:nil];
+
+					// The “list releases” endpoint (beta channel) returns an array;
+					// reduce it to the best entry. Empty dictionary keeps us on the
+					// “Incomplete server response” path when nothing qualifies.
+					if([plist isKindOfClass:NSArray.class])
+						plist = OakSelectGitHubRelease(plist, ![updateChannel isEqualToString:kSoftwareUpdateChannelRelease]) ?: @{ };
 
 					if([plist isKindOfClass:NSDictionary.class])
 					{

--- a/Frameworks/SoftwareUpdate/tests/t_OakCompareVersionStrings.mm
+++ b/Frameworks/SoftwareUpdate/tests/t_OakCompareVersionStrings.mm
@@ -23,6 +23,19 @@ void test_trailing_zero ()
 	OAK_ASSERT_EQ(OakCompareVersionStrings(@"2.1-beta",      @"2.0"),          NSOrderedDescending);
 }
 
+// The fork's actual tag forms: stable releases are X.Y.Z-undead, betas are
+// X.Y.Z-undead-beta.N (and one legacy 2.0.23-undead.0). Beta channel users
+// must be offered the next beta AND the stable that supersedes their beta.
+void test_undead_versions ()
+{
+	OAK_ASSERT_EQ(OakCompareVersionStrings(@"2.1.2-undead-beta.1",  @"2.1.2-undead"),         NSOrderedAscending);
+	OAK_ASSERT_EQ(OakCompareVersionStrings(@"2.1.2-undead-beta.1",  @"2.1.2-undead-beta.2"),  NSOrderedAscending);
+	OAK_ASSERT_EQ(OakCompareVersionStrings(@"2.1.2-undead-beta.2",  @"2.1.2-undead-beta.10"), NSOrderedAscending);
+	OAK_ASSERT_EQ(OakCompareVersionStrings(@"2.1.1-undead",         @"2.1.2-undead-beta.1"),  NSOrderedAscending);
+	OAK_ASSERT_EQ(OakCompareVersionStrings(@"2.0.23-undead.0",      @"2.1.0-undead"),         NSOrderedAscending);
+	OAK_ASSERT_EQ(OakCompareVersionStrings(@"2.1.2-undead",         @"2.1.2-undead"),         NSOrderedSame);
+}
+
 void test_null_string ()
 {
 	OAK_ASSERT_EQ(OakCompareVersionStrings(nil, @"2.0"), NSOrderedAscending);

--- a/Frameworks/SoftwareUpdate/tests/t_OakSelectGitHubRelease.mm
+++ b/Frameworks/SoftwareUpdate/tests/t_OakSelectGitHubRelease.mm
@@ -1,0 +1,66 @@
+#import <SoftwareUpdate/SoftwareUpdate.h>
+
+// Entries mirror the GitHub “list releases” schema (see the live capture from
+// api.github.com/repos/textmatelives/textmate/releases): only tag_name,
+// prerelease, and draft matter for selection.
+static NSDictionary* release_entry (NSString* tag, BOOL prerelease = NO, BOOL draft = NO)
+{
+	return @{ @"tag_name": tag, @"prerelease": @(prerelease), @"draft": @(draft) };
+}
+
+void test_stable_only_list ()
+{
+	// Current live state: no prereleases published yet. The beta channel must
+	// still resolve the newest stable.
+	NSArray* releases = @[ release_entry(@"v2.1.1-undead"), release_entry(@"v2.1.0-undead") ];
+	OAK_ASSERT_EQ(OakSelectGitHubRelease(releases, YES)[@"tag_name"], @"v2.1.1-undead");
+	OAK_ASSERT_EQ(OakSelectGitHubRelease(releases, NO)[@"tag_name"],  @"v2.1.1-undead");
+}
+
+void test_mixed_list ()
+{
+	NSArray* betaLeads = @[
+		release_entry(@"v2.1.2-undead-beta.1", YES),
+		release_entry(@"v2.1.1-undead"),
+	];
+	OAK_ASSERT_EQ(OakSelectGitHubRelease(betaLeads, YES)[@"tag_name"], @"v2.1.2-undead-beta.1");
+	OAK_ASSERT_EQ(OakSelectGitHubRelease(betaLeads, NO)[@"tag_name"],  @"v2.1.1-undead");
+
+	// Stable catches up with the beta cycle: beta channel converges onto it.
+	NSArray* stableLeads = @[
+		release_entry(@"v2.1.2-undead"),
+		release_entry(@"v2.1.2-undead-beta.2", YES),
+		release_entry(@"v2.1.1-undead"),
+	];
+	OAK_ASSERT_EQ(OakSelectGitHubRelease(stableLeads, YES)[@"tag_name"], @"v2.1.2-undead");
+	OAK_ASSERT_EQ(OakSelectGitHubRelease(stableLeads, NO)[@"tag_name"],  @"v2.1.2-undead");
+}
+
+void test_selection_by_version_not_position ()
+{
+	// GitHub orders by creation date: a hotfix published after a newer beta
+	// appears first in the array but must not win.
+	NSArray* releases = @[
+		release_entry(@"v2.1.1-undead"),
+		release_entry(@"v2.1.2-undead-beta.1", YES),
+	];
+	OAK_ASSERT_EQ(OakSelectGitHubRelease(releases, YES)[@"tag_name"], @"v2.1.2-undead-beta.1");
+}
+
+void test_skips_unusable_entries ()
+{
+	NSArray* releases = @[
+		release_entry(@"v9.9.9-undead", NO, YES), // draft
+		@"not a dictionary",
+		@{ @"prerelease": @NO, @"draft": @NO },   // no tag_name
+		release_entry(@"v2.1.1-undead"),
+	];
+	OAK_ASSERT_EQ(OakSelectGitHubRelease(releases, YES)[@"tag_name"], @"v2.1.1-undead");
+}
+
+void test_no_acceptable_entry ()
+{
+	OAK_ASSERT(OakSelectGitHubRelease(@[ ], YES) == nil);
+	OAK_ASSERT(OakSelectGitHubRelease(nil, YES) == nil);
+	OAK_ASSERT(OakSelectGitHubRelease(@[ release_entry(@"v2.1.2-undead-beta.1", YES) ], NO) == nil);
+}


### PR DESCRIPTION
## Summary

All three update channels pointed at `releases/latest`, which excludes GitHub prereleases by definition, so the beta channel could never offer one and its "Prereleases" menu item had been removed from the prefs dropdown. This makes the beta channel real.

- **`OakSelectGitHubRelease(releases, includePrereleases)`** — given a GitHub "list releases" response, picks the highest-version non-draft entry per `OakCompareVersionStrings`. Selection is by version, not array position (the list is creation-ordered; a hotfix published after a newer beta must not win). Stables are included so beta users converge back onto the stable release once it catches up with the beta cycle.
- **Feed parser accepts arrays** — the list endpoint returns a JSON array, which previously fell into the "Malformed server response" branch. Arrays are reduced via `OakSelectGitHubRelease` before `OakExtractUpdateInfo`; an empty selection routes to the existing "Incomplete server response" path.
- **Channel re-point** — beta now fetches `/releases?per_page=20`; Release stays on `releases/latest`; Canary too (no nightly stream exists).
- **Prefs UI** — "Prereleases" menu item (tag 1) and the `kSoftwareUpdateChannelPrerelease` transformer entry restored.
- **Publishing** — `release.yml` adds `--prerelease` to `gh release create` when the CHANGELOG version matches `*-beta*`, keeping `releases/latest` (the stable feed) on the stable build. A beta release is therefore just a CHANGELOG entry whose version is `vX.Y.Z-undead-beta.N`. `bin/extract_changes` needs no change (exact string match on the version).

## Tests

- `t_OakCompareVersionStrings.mm`: ordering assertions for the fork's real tag forms (`2.1.2-undead-beta.1 < 2.1.2-undead`, `beta.2 < beta.10`, `2.1.1-undead < 2.1.2-undead-beta.1`, legacy `2.0.23-undead.0`). The existing comparator passed all of them unchanged.
- `t_OakSelectGitHubRelease.mm` (new): stable-only list, mixed lists in both orders, position trap, draft/garbage/missing-tag entries, empty list, prerelease-only list with prereleases excluded.

## Runtime verification

Driven in the running app (channel set to beta, real menu action triggered):

- Doctored local feed with a fabricated `v2.1.2-undead-beta.1` prerelease placed second in the array behind a stable → offer dialog: "TextMate 2.1.2-undead-beta.1 is now available. You have version 2.1.1-undead."
- Empty list `[]` → "Error Checking for Update — Incomplete server response."
- Live GitHub endpoint (no prereleases published yet) → "Up To Date. You are running 2.1.1-undead."
- Release channel → `releases/latest`, "Up To Date" (unchanged path).
- Preferences → Software Update popup shows "Prereleases" when the channel default is `beta`.

## Not covered here

Publishing the first actual beta (a CHANGELOG entry with a `-beta.N` version) is a follow-up action; until one exists the beta channel resolves the newest stable, as verified above.