### PR TITLE
Gate Apple signing secrets behind the release environment

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,10 @@ jobs:
   release:
     needs: verify   # publish only if build AND test passed
     runs-on: macos-26
+    # Gates the Apple signing secrets behind a required reviewer. Without
+    # this, release.yml is reachable by workflow_dispatch, which needs only
+    # write access, and the signing identity is exposed to anyone holding it.
+    environment: release
     timeout-minutes: 60
     permissions:
       contents: write


### PR DESCRIPTION
## What

Adds `environment: release` to the `release` job.

## Why

`release.yml` is reachable via `workflow_dispatch`, and [manually running a
workflow](https://docs.github.com/en/actions/managing-workflow-runs-and-deployments/managing-workflow-runs/manually-running-a-workflow)
requires only **write** access. The five Apple signing secrets
(`MAC_CERTIFICATE_P12`, `MAC_CERTIFICATE_PWD`, `APPLE_ID`, `APPLE_ID_PWD`,
`APPLE_TEAM_ID`) are plain repository secrets with no environment protection,
so any write-role account could trigger a signed release — or add a workflow
on a branch that simply prints them.

A `release` environment now exists on this repo with:

- **Required reviewer:** @dayglojesus
- **Deployment branch policy:** protected branches only

Referencing it from the job makes the release wait for approval and blocks
dispatch from unprotected branches.

## Follow-up required — this PR alone is not sufficient

The secrets are still **repository** secrets, which every job in the repo can
read regardless of environment. Secret values cannot be read back through the
API, so they could not be migrated automatically. To finish:

1. Re-add all five as **environment** secrets under `release`.
2. Delete the five repository-level secrets.

Until that is done the environment gate controls *when the release job runs*,
but not *who can read the secrets*.

## Risk

Low. No build, signing, or notarization logic changed — only job placement
behind an approval gate. First release after merge will pause for approval,
which is the intent.
