### PR TITLE
Pin actions/checkout to a full commit SHA

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: macos-26   # Xcode 26.4.1 default → actool .icon support
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
         with:
           submodules: recursive
 
@@ -30,7 +30,7 @@ jobs:
     runs-on: macos-26   # Xcode 26.4.1 default → actool .icon support
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
         with:
           submodules: recursive
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ jobs:
       CERT_IDENTITY_NAME: "Developer ID Application"
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
         with:
           submodules: recursive
           fetch-depth: 0


### PR DESCRIPTION
Addresses **D3** in `FIXES.md`.

## What

Pins `actions/checkout` to a full commit SHA in `build-and-test.yml` (×2) and
`release.yml` (×1). The `# v5` trailing comment keeps the human-readable
version visible.

```
- uses: actions/checkout@v5
+ uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
```

## Why

A version tag is a moving pointer. Whoever controls the upstream repo can
repoint `v5` at different code, and every workflow referencing it picks that up
on the next run — with this repo's Apple signing secrets in scope. A full SHA
is immutable.

`actions/checkout`'s `v5` was verified to be a **lightweight** tag pointing
directly at commit `fbc6f39`, so the SHA above is the commit, not a tag object.

## Blocks D3

`sha_pinning_required` cannot be turned on for this repo until this merges — it
would fail the workflows as currently written. Once merged:

```
gh api -X PUT repos/textmatelives/textmate/actions/permissions \
  -F enabled=true -F allowed_actions=selected -F sha_pinning_required=true
```

## Verification

All three workflows re-parsed with `ruby -ryaml` after the edit. Local
reusable-workflow references (`./.github/workflows/build-and-test.yml`) are
untouched — they are exempt from both allowlist and pinning rules.

## Risk

Low. Same action, same version, immutable reference. No logic changed.
