### PR TITLE
Add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,16 @@
+# Code owners for textmatelives/textmate.
+#
+# Ownership drives automatic review requests on every pull request. It is not
+# by itself an enforcement mechanism: the `protect-default-branch` ruleset
+# currently has `require_code_owner_review: false`, and merging is already
+# limited to OrganizationAdmin by that ruleset's `update` rule.
+#
+# Flip `require_code_owner_review` to true once there is more than one
+# maintainer, so ownership becomes a gate rather than a notification.
+#
+# https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+*                        @dayglojesus
+
+# Anything that can reach the Apple signing identity.
+/.github/workflows/      @dayglojesus


### PR DESCRIPTION
Addresses **E1** in `FIXES.md`.

Adds `.github/CODEOWNERS` assigning @dayglojesus as owner of everything, with an explicit entry for `/.github/workflows/` — the path that can reach the Apple signing identity.

**This is a notification mechanism, not a gate.** The ruleset has `require_code_owner_review: false`, and merging is already limited to `OrganizationAdmin` by the `update` rule, so nothing changes about who can merge. What it does add is an automatic review request on every PR, and a visible owner for the workflow directory.

Worth flipping `require_code_owner_review` to true once a second maintainer exists — with a single owner it is redundant with the `update` rule.