### PR TITLE
Build tooling: make the Ruby helper scripts Ruby 3 compatible

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ TextMate is a trademark of Allan Odgaard.
 [boost]:         http://www.boost.org/
 [ninja]:         https://ninja-build.org/
 [multimarkdown]: http://fletcherpenney.net/multimarkdown/
-[ragel]:         http://www.complang.org/ragel/
+[ragel]:         https://www.colm.net/open-source/ragel/
 [MacPorts]:      http://www.macports.org/
 [Homebrew]:      http://brew.sh/
 [NinjaBundle]:   https://github.com/textmate/ninja.tmbundle

--- a/bin/expand_variables
+++ b/bin/expand_variables
@@ -1,4 +1,4 @@
-#!/System/Library/Frameworks/Ruby.framework/Versions/Current/usr/bin/ruby
+#!/usr/bin/env ruby
 require 'optparse'
 require 'shellwords'
 

--- a/bin/extract_changes
+++ b/bin/extract_changes
@@ -1,4 +1,4 @@
-#!/System/Library/Frameworks/Ruby.framework/Versions/Current/usr/bin/ruby -w
+#!/usr/bin/env ruby -w
 require 'optparse'
 
 outfile = nil

--- a/bin/gen_build
+++ b/bin/gen_build
@@ -1,4 +1,4 @@
-#!/System/Library/Frameworks/Ruby.framework/Versions/Current/usr/bin/ruby
+#!/usr/bin/env ruby
 require 'optparse'
 
 if __FILE__ == $PROGRAM_NAME

--- a/bin/gen_credits.rb
+++ b/bin/gen_credits.rb
@@ -8,10 +8,61 @@ require 'fileutils'
 require 'net/https'
 require 'uri'
 require 'cgi'
-require 'dbm'
 require 'date'
 require 'json'
 require 'set'
+
+# Persistent string -> string map backing the lookup cache below.
+#
+# This used to be DBM. Ruby 3.4 dropped dbm from the standard library, so a
+# script with `#!/usr/bin/env ruby` fails to even load on a machine whose PATH
+# Ruby is 3.4+. JSON is core, gives identical semantics for this cache, and has
+# the side benefit of being readable when the cache needs inspecting.
+#
+# Writes are buffered and flushed once at exit rather than on every assignment,
+# since initialize() seeds several dozen entries in a row.
+class CacheStore
+  def initialize(path)
+    @path  = "#{path}.json"
+    @dirty = false
+    FileUtils.mkdir_p(File.dirname(@path))
+    @entries = load_entries
+    at_exit { save }
+  end
+
+  def [](key)
+    @entries[key]
+  end
+
+  def []=(key, value)
+    value = value.to_s
+    return if @entries[key] == value
+    @entries[key] = value
+    @dirty = true
+  end
+
+  def has_key?(key)
+    @entries.has_key?(key)
+  end
+
+  def save
+    return unless @dirty
+    tmp = "#{@path}~"
+    File.open(tmp, 'w') { |io| io << JSON.pretty_generate(@entries) }
+    File.rename(tmp, @path)
+    @dirty = false
+  end
+
+  private
+
+  def load_entries
+    return {} unless File.exist?(@path)
+    parsed = JSON.parse(File.read(@path))
+    parsed.is_a?(Hash) ? parsed : {}
+  rescue JSON::ParserError, SystemCallError
+    {}  # unreadable or corrupt cache is not fatal; it just gets rebuilt
+  end
+end
 
 # Helper class to handle searching for GitHub users
 # by their email address. Caches mappings to a file
@@ -19,9 +70,8 @@ require 'set'
 # anonymous requests.
 class GitHubLookup
 
-  def self.initialize(dbm_file)
-    FileUtils.mkdir_p(File.dirname(dbm_file))
-    @db = DBM.new(dbm_file, 0644, DBM::WRCREAT)
+  def self.initialize(cache_file)
+    @db = CacheStore.new(cache_file)
     # seed with some contributors that don't have an email
     # address assigned publicly in their account
     @db['1178ce2f664a6cee9a05a3e11af5d8d2'] = 'aaronbrethorst'
@@ -67,7 +117,6 @@ class GitHubLookup
     # textmatelives fork contributors
     @db['8c31c603c339e672556eb6a80755b790'] = 'dayglojesus'  # dayglojesus@gmail.com
     @db['01209ad974dd6086f1275ba21ccf8e2e'] = 'dayglojesus'  # dayglojesus@users.noreply.github.com
-    ObjectSpace.define_finalizer(@db, proc {|id| @db.close })
   end
 
   # Resolve a commit author's GitHub login. The legacy "search user by
@@ -130,8 +179,8 @@ def detect_log_ref
   %w[origin/main main HEAD].find { |r| system("git rev-parse --verify --quiet #{r} >/dev/null") } || 'HEAD'
 end
 
-def generate_credits(dbm_file, warn=false)
-  GitHubLookup.initialize(dbm_file)
+def generate_credits(cache_file, warn=false)
+  GitHubLookup.initialize(cache_file)
   did_warn_db = Set.new
   repo = detect_github_repo
   log_ref = detect_log_ref

--- a/bin/gen_credits.rb
+++ b/bin/gen_credits.rb
@@ -1,4 +1,4 @@
-#!/System/Library/Frameworks/Ruby.framework/Versions/Current/usr/bin/ruby
+#!/usr/bin/env ruby
 # == Synopsis
 #
 # Module to assist in building the Contributors page using git commit history.
@@ -67,7 +67,7 @@ class GitHubLookup
     # textmatelives fork contributors
     @db['8c31c603c339e672556eb6a80755b790'] = 'dayglojesus'  # dayglojesus@gmail.com
     @db['01209ad974dd6086f1275ba21ccf8e2e'] = 'dayglojesus'  # dayglojesus@users.noreply.github.com
-    ObjectSpace.define_finalizer(@db, proc {|id| db.close })
+    ObjectSpace.define_finalizer(@db, proc {|id| @db.close })
   end
 
   # Resolve a commit author's GitHub login. The legacy "search user by

--- a/bin/gen_html
+++ b/bin/gen_html
@@ -1,4 +1,4 @@
-#!/System/Library/Frameworks/Ruby.framework/Versions/Current/usr/bin/ruby
+#!/usr/bin/env ruby
 # encoding: utf-8
 Encoding.default_external = Encoding::UTF_8
 Encoding.default_internal = Encoding::UTF_8

--- a/bin/gen_html
+++ b/bin/gen_html
@@ -6,7 +6,7 @@ require 'optparse'
 require 'erb'
 
 def expand_tpl(str, binding)
-  ERB.new(str, 0, '%-').result(binding)
+  ERB.new(str, trim_mode: '%-').result(binding)
 end
 
 def expand_tpl_file(path, binding)

--- a/bin/gen_test
+++ b/bin/gen_test
@@ -1,4 +1,4 @@
-#!/System/Library/Frameworks/Ruby.framework/Versions/Current/usr/bin/ruby -w
+#!/usr/bin/env ruby -w
 require 'pathname'
 require 'erb'
 

--- a/bin/gen_test
+++ b/bin/gen_test
@@ -30,7 +30,7 @@ ARGV.each do |file|
   end
 end
 
-STDOUT << ERB.new(DATA.read, 0, '-<>').result(binding)
+STDOUT << ERB.new(DATA.read, trim_mode: '-<>').result(binding)
 
 __END__
 #line 37 "<%= $PROGRAM_NAME %>"

--- a/bin/update_changes
+++ b/bin/update_changes
@@ -1,4 +1,4 @@
-#!/System/Library/Frameworks/Ruby.framework/Versions/Current/usr/bin/ruby -w
+#!/usr/bin/env ruby -w
 require 'optparse'
 require 'shellwords'
 


### PR DESCRIPTION
Makes the Ruby helper scripts work on Ruby 3.x. Three upstream/community patches, original authorship preserved.

## Why

`bin/gen_test` and `bin/gen_html` call `ERB.new` with the positional `safe_level` / `trim_mode` arguments that Ruby deprecated in 2.6. Against current `main`, unmodified:

```
$ ./bin/gen_test Frameworks/text/tests/t_*.cc
./bin/gen_test:33: warning: Passing safe_level with the 2nd argument of ERB.new is deprecated.
                   Do not use it, and specify other arguments as keyword arguments.
./bin/gen_test:33: warning: Passing trim_mode with the 3rd argument of ERB.new is deprecated.
                   Use keyword argument like ERB.new(str, trim_mode: ...) instead.
```

Ruby's own `erb.rb` calls this "Complex initializer for $SAFE deprecation at Feature #14256, **which should be removed at Ruby 2.7**".

Nothing is broken today only because seven of our helpers are pinned by absolute shebang to Apple's Ruby 2.6, while `bin/rave` uses `env ruby`:

```
bin/rave                    #!/usr/bin/env ruby
bin/gen_test, gen_html,     #!/System/Library/Frameworks/Ruby.framework/Versions/Current/usr/bin/ruby
bin/gen_build, gen_credits.rb,
bin/expand_variables, bin/extract_changes,
bin/update_changes
```

That split is the hazard. The moment the shebangs are unified — or Apple drops the 2.6 framework — `gen_test` and `gen_html` break for anyone with Ruby 3.x in `PATH`. **The two changes therefore belong together**, ERB fix first, shebangs second. Taking the shebang cleanup alone would be a regression.

## Commits

| Commit | Author | Source |
|---|---|---|
| Modernize ERB usage to eliminate Ruby 3.x deprecation warnings | Copilot | [tectiv3/textmate@06f793bb](https://github.com/tectiv3/textmate/commit/06f793bb) |
| Fix Ruby scripts (shebangs → `env ruby`, drop `$KCODE`, fix `db.close` → `@db.close`) | Geremia Taglialatela | [tectiv3/textmate@34e4310b](https://github.com/tectiv3/textmate/commit/34e4310b) |
| Fix broken hyperlink to Ragel | Deepak Mantena | [textmate/textmate#1460](https://github.com/textmate/textmate/pull/1460) |
| Replace DBM with a JSON cache in `gen_credits.rb` | (this PR) | — |

Two conflicts came up and were resolved in favour of this fork:

- `bin/gen_html` — kept our `Encoding.default_external/internal` preamble, took the new shebang.
- `bin/gen_credits.rb` — kept our fork-contributor seed entries, took the `ObjectSpace.define_finalizer(@db, proc {|id| @db.close })` fix. The original referenced an undefined local `db`, which would raise `NameError` if the finalizer ever ran.
- `README.md` — took the new Ragel URL, **did not** reintroduce the `[capnp]` link that we removed when Cap'n Proto was dropped.

## Verification

On this branch, macOS 26.5 / Ruby 2.6.10:

- `./bin/gen_test Frameworks/text/tests/t_*.cc` — exit 0, **stderr empty** (was two deprecation warnings).
- Generated runner is byte-identical to `main`'s output apart from the embedded build timestamp.
- `./bin/gen_html --help` — exit 0, no warnings.
- `ruby -c` clean on all eight scripts including `bin/rave`.
- Confirmed `#!/usr/bin/env ruby -w` still yields `$VERBOSE=true` on macOS, identical to the absolute-path shebang. Worth stating explicitly: if `env` had swallowed the `-w`, the warnings would merely have been *hidden* rather than fixed, and the empty stderr above would have proved nothing. (This relies on macOS `env` splitting shebang arguments; it is not portable to Linux, which is fine for a macOS-only project.)

## The DBM trap

The first push of this branch **broke the build**, and it is worth recording why rather than quietly force-pushing over it.

`bin/gen_html` evaluates `bin/gen_credits.rb` from inside the `Contributions.md` ERB template. Once `gen_html` runs under `env ruby`, that is Homebrew **Ruby 3.4.10** on the CI runner — and Ruby 3.4 removed `dbm` from the standard library:

```
[246/1096] Markdown ‘Applications/TextMate/about/Contributions.md’…
FAILED: [code=1] .../_CompileMarkdown/Applications/TextMate/about/Contributions.html
  kernel_require.rb:139:in 'Kernel#require': cannot load such file -- dbm (LoadError)
  from bin/gen_credits.rb:11:in '<top (required)>'
```

This did not reproduce locally because `env ruby` resolves to the same Apple Ruby 2.6 that the old shebang pointed at, where `dbm` is still stdlib. Testing on the developer machine proved nothing about the target.

The fix removes the dependency rather than pinning `gen_credits.rb` back to Apple's Ruby, since the whole point is to stop relying on an interpreter Apple is removing. The cache is a flat string → string map that exists only to avoid re-querying the GitHub API, so JSON is an exact fit — core in every supported Ruby, legible on disk. An existing `githubcredits.db` is left alone; the new store writes `githubcredits.json` alongside it and repopulates on first run.

`CacheStore` was checked against `DBM` directly on the same operation sequence — get, set, overwrite, `has_key?`, empty-value — plus persistence across reopen and a deliberately corrupted cache file. Identical results throughout.

Every `require` across `bin/` was then audited against Ruby 3.4 rather than fixing only the one that bit: thirteen distinct requires, and `dbm` was the only casualty. CI had already loaded `cgi`, `uri` and `net/https` successfully before dying at line 11.

## CI

`build-and-test / build` **pass**, `build-and-test / test` **pass**.

## Not included

`README.md` still points `[sparsehash]` at the defunct `code.google.com`. Out of scope here; happy to do it separately.