### PR TITLE
Release v2.1.5-undead

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,38 @@ Title: Release Notes
 
 # Changes
 
+## 2026-08-21 (v2.1.5-undead)
+
+Maintenance release: seven stalled community fixes adopted from the upstream PR queue, the Ruby build helpers brought up to Ruby 3, and the unused SyntaxMate XPC service removed. See [all changes since v2.1.4-undead](https://github.com/textmatelives/textmate/compare/v2.1.4-undead...v2.1.5-undead).
+
+### Editor
+
+* **File browser and document view backgrounds render correctly again.** ([#39](https://github.com/textmatelives/textmate/pull/39), `b87d4641`)
+* **`attr.filebrowser` is now set while the file browser pane has focus,** so scoped settings and key bindings can target it. ([#39](https://github.com/textmatelives/textmate/pull/39), `5e39c5ee`)
+* **Corrected a "toggleing" typo in Preferences.** ([#39](https://github.com/textmatelives/textmate/pull/39), `6236dcb0`)
+
+### Stability
+
+* **Avoided a clang 15 crash in Find** caused by an incorrect array size. ([#39](https://github.com/textmatelives/textmate/pull/39), `d115b6f7`)
+* **Fixed an incorrect number of seconds in a day** in `format_string`. ([#39](https://github.com/textmatelives/textmate/pull/39), `9a41ea5c`)
+* **Fixed a cast of a non-Objective-C pointer in `shared_ptr`** in RMateServer. ([#39](https://github.com/textmatelives/textmate/pull/39), `62ad24f4`)
+* **Silenced the `vfork` deprecation warning on macOS Monterey,** pending migration to `posix_spawn`. ([#39](https://github.com/textmatelives/textmate/pull/39), `bb047ecb`)
+
+### Build tooling
+
+* **The Ruby helper scripts are Ruby 3 compatible.** ERB usage was modernized to eliminate deprecation warnings. ([#38](https://github.com/textmatelives/textmate/pull/38), `fc835f67`)
+* **`gen_credits.rb` uses a JSON cache instead of DBM,** which is no longer bundled with Ruby 3. ([#38](https://github.com/textmatelives/textmate/pull/38), `c187e5dc`)
+
+### Housekeeping
+
+* **Removed the unused SyntaxMate XPC service.** ([#40](https://github.com/textmatelives/textmate/pull/40), `129c1b03`)
+
+### Release infrastructure
+
+* **The Apple signing identity is gated behind a required reviewer.** The signing secrets moved from repository scope into a `release` environment, so a signed build cannot be produced without explicit approval. ([#34](https://github.com/textmatelives/textmate/pull/34), `b00a4ee7`)
+* **`actions/checkout` is pinned to a full commit SHA** in every workflow, with SHA pinning now enforced repository-wide. ([#35](https://github.com/textmatelives/textmate/pull/35), `4c8f75dc`)
+* **Added `CODEOWNERS`.** ([#36](https://github.com/textmatelives/textmate/pull/36), `8b1c6b8b`)
+
 ## 2026-06-11 (v2.1.4-undead)
 
 Bugfix release: the GitHub Markdown preview no longer dies with a `LoadError` on installs that predate 2026-06-08 ([#29](https://github.com/textmatelives/textmate/issues/29)). See [all changes since v2.1.3-undead](https://github.com/textmatelives/textmate/compare/v2.1.3-undead...v2.1.4-undead).


### PR DESCRIPTION
Cuts **v2.1.5-undead**. Adds the `CHANGELOG.md` entry; merging this to `main` fires `release.yml` via its `paths: [CHANGELOG.md]` trigger.

## Contents

23 commits since `v2.1.4-undead`:

- **#39** — seven stalled community fixes from the upstream PR queue (file browser/document view backgrounds, `attr.filebrowser` on focus, a clang 15 crash in Find, seconds-in-a-day in `format_string`, a `shared_ptr` cast in RMateServer, the Monterey `vfork` warning, a Preferences typo)
- **#38** — Ruby 3 compatibility for the build helpers (ERB modernization, DBM → JSON cache in `gen_credits.rb`)
- **#40** — removal of the unused SyntaxMate XPC service
- **#34 / #35 / #36** — release-infrastructure hardening

Every bullet is tied to a commit SHA verified against `git compare v2.1.4-undead...main`.

## Pre-flight

Checked before opening, against the real parsers rather than assumed:

| Check | Result |
|---|---|
| `grep -om1 '^## .* (v.*)$'` → version | `2.1.5-undead` |
| Contains `-undead` (guard) | yes — `should_release=true` |
| Tag `v2.1.5-undead` exists | no — will release |
| `bin/extract_changes -v 2.1.5-undead` | extracts this section only, exit 0 |
| Diff shape | +32 / -0, purely additive |

The `extract_changes` check matters: that step runs at **#18, after notarization at #14**, so a malformed heading would fail only after the signing cycle had been spent.

## What happens on merge

1. `verify` (build + test) runs unapproved — no environment, no secrets.
2. `release` holds at **"Waiting for review"**.
3. On approval: sign → notarize → staple → publish tag `v2.1.5-undead` and a GitHub release with a `.tbz`.

**This publishes a real, public release.** There is no dry-run path — the guards either skip everything or do everything.

This is also the first run to actually read the environment-scoped signing secrets. They have been verified by local round-trip (the base64 decodes to fingerprint `E666E23B…`, matching the keychain identity, and the recorded password opens the `.p12`), but never exercised in CI. If either was mis-transferred it fails at **step 5, "Import signing certificate into temporary keychain"** — before notarization, and cheap to recover from.

## Note

The date reads `2026-08-21` (local). Adjust if it slips before merge — cosmetic, not parsed for anything but display.
