### PR TITLE
Fix crash on launch from strict plist field reads

### DIFF
--- a/Applications/NewApplication/CMakeLists.txt
+++ b/Applications/NewApplication/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_executable(NewApplication MACOSX_BUNDLE)
-file(GLOB _src src/*.cc src/*.mm)
+file(GLOB _src CONFIGURE_DEPENDS src/*.cc src/*.mm)
 target_sources(NewApplication PRIVATE ${_src})
 target_link_libraries(NewApplication PRIVATE
   OakFoundation OakAppKit MenuBuilder OakDebug "-framework Cocoa")

--- a/Applications/PrivilegedTool/CMakeLists.txt
+++ b/Applications/PrivilegedTool/CMakeLists.txt
@@ -1,4 +1,4 @@
 add_executable(PrivilegedTool)
-file(GLOB _src src/*.cc src/*.mm)
+file(GLOB _src CONFIGURE_DEPENDS src/*.cc src/*.mm)
 target_sources(PrivilegedTool PRIVATE ${_src})
 target_link_libraries(PrivilegedTool PRIVATE authorization io text ${TEXTMATE_DEBUG_LIBS})

--- a/Applications/QuickLookGenerator/CMakeLists.txt
+++ b/Applications/QuickLookGenerator/CMakeLists.txt
@@ -1,6 +1,6 @@
 # .qlgenerator bundle, not a regular app
 add_library(TextMateQL MODULE)
-file(GLOB _src src/*.c src/*.mm)
+file(GLOB _src CONFIGURE_DEPENDS src/*.c src/*.mm)
 target_sources(TextMateQL PRIVATE ${_src})
 
 # Info.plist refers to ${TARGET_NAME}, which rave's expand_variables filled in.
@@ -25,7 +25,7 @@ textmate_codesign(TextMateQL "${CS_IDENTITY}")
 # rave propagates a framework's `files resources/* "Resources"` into every
 # target that requires it, so TextMateQL picks up OakAppKit's and scm's
 # resources as well as its own. CMake has no equivalent, so list them.
-file(GLOB _ql_res
+file(GLOB _ql_res CONFIGURE_DEPENDS
   "${CMAKE_SOURCE_DIR}/Frameworks/OakAppKit/resources/Charsets.plist"
   "${CMAKE_SOURCE_DIR}/Frameworks/scm/resources/svn_status.xslt"
   "${CMAKE_SOURCE_DIR}/Frameworks/OakAppKit/gfx/CloseButton/*.png")

--- a/Applications/TextMate/CMakeLists.txt
+++ b/Applications/TextMate/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_executable(TextMate MACOSX_BUNDLE)
-file(GLOB _src src/*.cc src/*.mm)
+file(GLOB _src CONFIGURE_DEPENDS src/*.cc src/*.mm)
 target_sources(TextMate PRIVATE ${_src})
 
 # Internal framework dependencies
@@ -58,11 +58,11 @@ target_xib_sources(TextMate "English.lproj"
   "${CMAKE_SOURCE_DIR}/Frameworks/BundleEditor/resources/English.lproj/GrammarProperties.xib")
 
 # Icon and image resources
-file(GLOB _icons icons/*.icns)
+file(GLOB _icons CONFIGURE_DEPENDS icons/*.icns)
 # resources/* excluding "TextMate Help" and English.lproj: the Help directory
 # is rendered from Markdown below (globbing it here would also copy the .md
 # sources into the bundle) and the xibs are compiled to .nib separately.
-file(GLOB _resources resources/*)
+file(GLOB _resources CONFIGURE_DEPENDS resources/*)
 list(FILTER _resources EXCLUDE REGEX "/(TextMate Help|English\\.lproj|textmate_lives\\.icon)$")
 set(_all_resources ${_icons} ${_resources})
 target_sources(TextMate PRIVATE ${_all_resources})
@@ -70,7 +70,7 @@ set_source_files_properties(${_all_resources} PROPERTIES
   MACOSX_PACKAGE_LOCATION Resources)
 
 # Framework resources (static libs can't carry resources, so they go in the app bundle)
-file(GLOB _fw_res
+file(GLOB _fw_res CONFIGURE_DEPENDS
   "${CMAKE_SOURCE_DIR}/Frameworks/Preferences/icons/*.png"
   "${CMAKE_SOURCE_DIR}/Frameworks/OakTextView/resources/*.pdf"
   "${CMAKE_SOURCE_DIR}/Frameworks/OakTextView/resources/*.tiff"
@@ -90,7 +90,7 @@ set_source_files_properties(${_fw_res} PROPERTIES
   MACOSX_PACKAGE_LOCATION Resources)
 
 # TMFileReference resources go in Resources/DocumentTypes/ subdirectory
-file(GLOB _doctype_res
+file(GLOB _doctype_res CONFIGURE_DEPENDS
   "${CMAKE_SOURCE_DIR}/Frameworks/TMFileReference/resources/*.icns"
   "${CMAKE_SOURCE_DIR}/Frameworks/TMFileReference/resources/bindings.plist")
 target_sources(TextMate PRIVATE ${_doctype_res})
@@ -107,21 +107,21 @@ textmate_markdown(TextMate "${CMAKE_SOURCE_DIR}/CHANGELOG.md" "About" ON)
 
 # The Help pages get the same header/footer treatment: rave's MD_FLAGS is set
 # on the whole TextMate target, so every .md it converts is wrapped.
-file(GLOB _help_md "resources/TextMate Help/*.md")
+file(GLOB _help_md CONFIGURE_DEPENDS "resources/TextMate Help/*.md")
 foreach(_md ${_help_md})
   textmate_markdown(TextMate "${_md}" "TextMate Help" ON)
 endforeach()
 
-file(GLOB _help_css "resources/TextMate Help/css/*")
-file(GLOB _help_img "resources/TextMate Help/images/*")
+file(GLOB _help_css CONFIGURE_DEPENDS "resources/TextMate Help/css/*")
+file(GLOB _help_img CONFIGURE_DEPENDS "resources/TextMate Help/images/*")
 target_sources(TextMate PRIVATE ${_help_css} ${_help_img})
 set_source_files_properties(${_help_css} PROPERTIES
   MACOSX_PACKAGE_LOCATION "Resources/TextMate Help/css")
 set_source_files_properties(${_help_img} PROPERTIES
   MACOSX_PACKAGE_LOCATION "Resources/TextMate Help/images")
 
-file(GLOB _about_css about/css/*)
-file(GLOB _about_js about/js/*)
+file(GLOB _about_css CONFIGURE_DEPENDS about/css/*)
+file(GLOB _about_js CONFIGURE_DEPENDS about/js/*)
 target_sources(TextMate PRIVATE ${_about_css} ${_about_js})
 set_source_files_properties(${_about_css} PROPERTIES
   MACOSX_PACKAGE_LOCATION "Resources/About/css")
@@ -129,7 +129,7 @@ set_source_files_properties(${_about_js} PROPERTIES
   MACOSX_PACKAGE_LOCATION "Resources/About/js")
 
 # Framework resources: rave's per-target `files resources/* "Resources"`.
-file(GLOB _fw_res
+file(GLOB _fw_res CONFIGURE_DEPENDS
   "${CMAKE_SOURCE_DIR}/Frameworks/BundleEditor/templates/*.plist"
   "${CMAKE_SOURCE_DIR}/Frameworks/SoftwareUpdate/resources/*"
   "${CMAKE_SOURCE_DIR}/Frameworks/scm/resources/*")

--- a/Applications/gtm/CMakeLists.txt
+++ b/Applications/gtm/CMakeLists.txt
@@ -1,4 +1,4 @@
 add_executable(gtm)
-file(GLOB _src src/*.cc)
+file(GLOB _src CONFIGURE_DEPENDS src/*.cc)
 target_sources(gtm PRIVATE ${_src})
 target_link_libraries(gtm PRIVATE parse ${TEXTMATE_DEBUG_LIBS})

--- a/Applications/indent/CMakeLists.txt
+++ b/Applications/indent/CMakeLists.txt
@@ -1,4 +1,4 @@
 add_executable(indent)
-file(GLOB _src src/*.cc)
+file(GLOB _src CONFIGURE_DEPENDS src/*.cc)
 target_sources(indent PRIVATE ${_src})
 target_link_libraries(indent PRIVATE text io regexp plist ${TEXTMATE_DEBUG_LIBS})

--- a/Applications/mate/CMakeLists.txt
+++ b/Applications/mate/CMakeLists.txt
@@ -1,6 +1,6 @@
 # rave: require authorization io plist text, frameworks ApplicationServices Security
 add_executable(mate)
-file(GLOB _src src/*.mm)
+file(GLOB _src CONFIGURE_DEPENDS src/*.mm)
 target_sources(mate PRIVATE ${_src})
 target_link_libraries(mate PRIVATE authorization io plist text ${TEXTMATE_DEBUG_LIBS}
   "-framework ApplicationServices" "-framework Security")

--- a/Applications/pretty_plist/CMakeLists.txt
+++ b/Applications/pretty_plist/CMakeLists.txt
@@ -1,4 +1,4 @@
 add_executable(pretty_plist)
-file(GLOB _src src/*.cc)
+file(GLOB _src CONFIGURE_DEPENDS src/*.cc)
 target_sources(pretty_plist PRIVATE ${_src})
 target_link_libraries(pretty_plist PRIVATE plist ${TEXTMATE_DEBUG_LIBS})

--- a/Applications/tm_query/CMakeLists.txt
+++ b/Applications/tm_query/CMakeLists.txt
@@ -1,4 +1,4 @@
 add_executable(tm_query)
-file(GLOB _src src/*.cc)
+file(GLOB _src CONFIGURE_DEPENDS src/*.cc)
 target_sources(tm_query PRIVATE ${_src})
 target_link_libraries(tm_query PRIVATE settings OakSystem ${TEXTMATE_DEBUG_LIBS})

--- a/Frameworks/BundleEditor/CMakeLists.txt
+++ b/Frameworks/BundleEditor/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_library(BundleEditor STATIC)
-file(GLOB _src src/*.cc src/*.mm)
+file(GLOB _src CONFIGURE_DEPENDS src/*.cc src/*.mm)
 target_sources(BundleEditor PRIVATE ${_src})
 textmate_framework(BundleEditor)
 target_link_libraries(BundleEditor PUBLIC

--- a/Frameworks/BundleMenu/CMakeLists.txt
+++ b/Frameworks/BundleMenu/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_library(BundleMenu STATIC)
-file(GLOB _src src/*.mm)
+file(GLOB _src CONFIGURE_DEPENDS src/*.mm)
 target_sources(BundleMenu PRIVATE ${_src})
 textmate_framework(BundleMenu)
 target_link_libraries(BundleMenu PUBLIC OakAppKit OakFoundation bundles text cf ns

--- a/Frameworks/BundlesManager/CMakeLists.txt
+++ b/Frameworks/BundlesManager/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_library(BundlesManager STATIC)
-file(GLOB _src src/*.cc src/*.mm)
+file(GLOB _src CONFIGURE_DEPENDS src/*.cc src/*.mm)
 target_sources(BundlesManager PRIVATE ${_src})
 textmate_framework(BundlesManager)
 target_link_libraries(BundlesManager PUBLIC

--- a/Frameworks/CommitWindow/CMakeLists.txt
+++ b/Frameworks/CommitWindow/CMakeLists.txt
@@ -1,6 +1,6 @@
 # Framework
 add_library(CommitWindow STATIC)
-file(GLOB _src src/*.mm)
+file(GLOB _src CONFIGURE_DEPENDS src/*.mm)
 target_sources(CommitWindow PRIVATE ${_src})
 textmate_framework(CommitWindow)
 target_link_libraries(CommitWindow PUBLIC

--- a/Frameworks/CrashReporter/CMakeLists.txt
+++ b/Frameworks/CrashReporter/CMakeLists.txt
@@ -3,7 +3,7 @@
 #
 # Not present in tectiv3/textmate — they removed the crash reporter.
 add_library(CrashReporter STATIC)
-file(GLOB _src src/*.mm)
+file(GLOB _src CONFIGURE_DEPENDS src/*.mm)
 target_sources(CrashReporter PRIVATE ${_src})
 textmate_framework(CrashReporter)
 target_link_libraries(CrashReporter PUBLIC

--- a/Frameworks/DocumentWindow/CMakeLists.txt
+++ b/Frameworks/DocumentWindow/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_library(DocumentWindow STATIC)
-file(GLOB _src src/*.mm)
+file(GLOB _src CONFIGURE_DEPENDS src/*.mm)
 target_sources(DocumentWindow PRIVATE ${_src})
 textmate_framework(DocumentWindow)
 target_link_libraries(DocumentWindow PUBLIC

--- a/Frameworks/FileBrowser/CMakeLists.txt
+++ b/Frameworks/FileBrowser/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_library(FileBrowser STATIC)
-file(GLOB _src src/*.mm src/OFB/*.mm)
+file(GLOB _src CONFIGURE_DEPENDS src/*.mm src/OFB/*.mm)
 target_sources(FileBrowser PRIVATE ${_src})
 textmate_framework(FileBrowser)
 target_link_libraries(FileBrowser PUBLIC

--- a/Frameworks/Find/CMakeLists.txt
+++ b/Frameworks/Find/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_library(Find STATIC)
-file(GLOB _src src/*.cc src/*.mm)
+file(GLOB _src CONFIGURE_DEPENDS src/*.cc src/*.mm)
 target_sources(Find PRIVATE ${_src})
 textmate_framework(Find)
 target_link_libraries(Find PUBLIC

--- a/Frameworks/HTMLOutput/CMakeLists.txt
+++ b/Frameworks/HTMLOutput/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_library(HTMLOutput STATIC)
-file(GLOB_RECURSE _src src/*.mm)
+file(GLOB_RECURSE _src CONFIGURE_DEPENDS src/*.mm)
 target_sources(HTMLOutput PRIVATE ${_src})
 textmate_framework(HTMLOutput)
 

--- a/Frameworks/HTMLOutputWindow/CMakeLists.txt
+++ b/Frameworks/HTMLOutputWindow/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_library(HTMLOutputWindow STATIC)
-file(GLOB _src src/*.mm)
+file(GLOB _src CONFIGURE_DEPENDS src/*.mm)
 target_sources(HTMLOutputWindow PRIVATE ${_src})
 textmate_framework(HTMLOutputWindow)
 target_link_libraries(HTMLOutputWindow PUBLIC HTMLOutput OakAppKit OakFoundation command ns

--- a/Frameworks/MenuBuilder/CMakeLists.txt
+++ b/Frameworks/MenuBuilder/CMakeLists.txt
@@ -1,6 +1,6 @@
 # rave: no require, frameworks Cocoa
 add_library(MenuBuilder STATIC)
-file(GLOB _src src/*.mm)
+file(GLOB _src CONFIGURE_DEPENDS src/*.mm)
 target_sources(MenuBuilder PRIVATE ${_src})
 textmate_framework(MenuBuilder)
 target_link_libraries(MenuBuilder PUBLIC "-framework Cocoa")

--- a/Frameworks/OakAppKit/CMakeLists.txt
+++ b/Frameworks/OakAppKit/CMakeLists.txt
@@ -1,7 +1,7 @@
 # rave: require OakFoundation bundles crash file io ns parse regexp settings text theme
 # frameworks Carbon Cocoa AudioToolbox Quartz, libraries sqlite3
 add_library(OakAppKit STATIC)
-file(GLOB _src src/*.cc src/*.mm)
+file(GLOB _src CONFIGURE_DEPENDS src/*.cc src/*.mm)
 target_sources(OakAppKit PRIVATE ${_src})
 textmate_framework(OakAppKit)
 target_link_libraries(OakAppKit PUBLIC

--- a/Frameworks/OakCommand/CMakeLists.txt
+++ b/Frameworks/OakCommand/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_library(OakCommand STATIC)
-file(GLOB _src src/*.mm)
+file(GLOB _src CONFIGURE_DEPENDS src/*.mm)
 target_sources(OakCommand PRIVATE ${_src})
 textmate_framework(OakCommand)
 target_link_libraries(OakCommand PUBLIC

--- a/Frameworks/OakDebug/CMakeLists.txt
+++ b/Frameworks/OakDebug/CMakeLists.txt
@@ -1,6 +1,6 @@
 # rave: require_headers text, frameworks Cocoa ExceptionHandling
 add_library(OakDebug STATIC)
-file(GLOB _src src/*.cc src/*.mm)
+file(GLOB _src CONFIGURE_DEPENDS src/*.cc src/*.mm)
 target_sources(OakDebug PRIVATE ${_src})
 textmate_framework(OakDebug)
 # require_headers = include dirs only, no linking

--- a/Frameworks/OakFilterList/CMakeLists.txt
+++ b/Frameworks/OakFilterList/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_library(OakFilterList STATIC)
-file(GLOB _src src/*.mm src/ui/*.mm)
+file(GLOB _src CONFIGURE_DEPENDS src/*.mm src/ui/*.mm)
 target_sources(OakFilterList PRIVATE ${_src})
 textmate_framework(OakFilterList)
 target_link_libraries(OakFilterList PUBLIC

--- a/Frameworks/OakFoundation/CMakeLists.txt
+++ b/Frameworks/OakFoundation/CMakeLists.txt
@@ -1,6 +1,6 @@
 # rave: require text
 add_library(OakFoundation STATIC)
-file(GLOB _src src/*.mm)
+file(GLOB _src CONFIGURE_DEPENDS src/*.mm)
 target_sources(OakFoundation PRIVATE ${_src})
 textmate_framework(OakFoundation)
 target_link_libraries(OakFoundation PUBLIC text "-framework Cocoa")

--- a/Frameworks/OakSystem/CMakeLists.txt
+++ b/Frameworks/OakSystem/CMakeLists.txt
@@ -1,6 +1,6 @@
 # rave: require cf io text
 add_library(OakSystem STATIC)
-file(GLOB _src src/*.cc)
+file(GLOB _src CONFIGURE_DEPENDS src/*.cc)
 target_sources(OakSystem PRIVATE ${_src})
 textmate_framework(OakSystem)
 target_link_libraries(OakSystem PUBLIC cf io text)

--- a/Frameworks/OakTabBarView/CMakeLists.txt
+++ b/Frameworks/OakTabBarView/CMakeLists.txt
@@ -1,6 +1,6 @@
 # rave: require OakFoundation OakAppKit TMFileReference, frameworks Cocoa
 add_library(OakTabBarView STATIC)
-file(GLOB _src src/*.mm)
+file(GLOB _src CONFIGURE_DEPENDS src/*.mm)
 target_sources(OakTabBarView PRIVATE ${_src})
 textmate_framework(OakTabBarView)
 target_link_libraries(OakTabBarView PUBLIC OakFoundation OakAppKit TMFileReference

--- a/Frameworks/OakTextView/CMakeLists.txt
+++ b/Frameworks/OakTextView/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_library(OakTextView STATIC)
-file(GLOB _src src/*.cc src/*.mm)
+file(GLOB _src CONFIGURE_DEPENDS src/*.cc src/*.mm)
 target_sources(OakTextView PRIVATE ${_src})
 textmate_framework(OakTextView)
 target_link_libraries(OakTextView PUBLIC

--- a/Frameworks/Preferences/CMakeLists.txt
+++ b/Frameworks/Preferences/CMakeLists.txt
@@ -1,7 +1,7 @@
 # rave: require BundlesManager OakAppKit OakFoundation MenuBuilder bundles io ns regexp settings text
 # require_headers OakTabBarView
 add_library(Preferences STATIC)
-file(GLOB _src src/*.mm)
+file(GLOB _src CONFIGURE_DEPENDS src/*.mm)
 target_sources(Preferences PRIVATE ${_src})
 textmate_framework(Preferences)
 target_link_libraries(Preferences PUBLIC

--- a/Frameworks/SoftwareUpdate/CMakeLists.txt
+++ b/Frameworks/SoftwareUpdate/CMakeLists.txt
@@ -8,7 +8,7 @@
 # Applications/TextMate/CMakeLists.txt, which is where framework resources are
 # gathered, matching how the xibs are handled.
 add_library(SoftwareUpdate STATIC)
-file(GLOB _src src/*.mm)
+file(GLOB _src CONFIGURE_DEPENDS src/*.mm)
 target_sources(SoftwareUpdate PRIVATE ${_src})
 textmate_framework(SoftwareUpdate)
 target_link_libraries(SoftwareUpdate PUBLIC

--- a/Frameworks/TMFileReference/CMakeLists.txt
+++ b/Frameworks/TMFileReference/CMakeLists.txt
@@ -1,6 +1,6 @@
 # rave: require_headers scm, frameworks Cocoa
 add_library(TMFileReference STATIC)
-file(GLOB _src src/*.mm)
+file(GLOB _src CONFIGURE_DEPENDS src/*.mm)
 target_sources(TMFileReference PRIVATE ${_src})
 textmate_framework(TMFileReference)
 target_include_directories(TMFileReference PRIVATE

--- a/Frameworks/authorization/CMakeLists.txt
+++ b/Frameworks/authorization/CMakeLists.txt
@@ -1,6 +1,6 @@
 # rave: require io text regexp OakSystem
 add_library(authorization STATIC)
-file(GLOB _src src/*.cc src/*.mm)
+file(GLOB _src CONFIGURE_DEPENDS src/*.cc src/*.mm)
 target_sources(authorization PRIVATE ${_src})
 textmate_framework(authorization)
 target_link_libraries(authorization PUBLIC io text regexp OakSystem)

--- a/Frameworks/buffer/CMakeLists.txt
+++ b/Frameworks/buffer/CMakeLists.txt
@@ -1,6 +1,6 @@
 # rave: require bundles io ns parse regexp scope text
 add_library(buffer STATIC)
-file(GLOB _src src/*.cc)
+file(GLOB _src CONFIGURE_DEPENDS src/*.cc)
 target_sources(buffer PRIVATE ${_src})
 textmate_framework(buffer)
 target_link_libraries(buffer PUBLIC bundles io ns parse regexp scope text)

--- a/Frameworks/bundles/CMakeLists.txt
+++ b/Frameworks/bundles/CMakeLists.txt
@@ -1,6 +1,6 @@
 # rave: require OakSystem io plist regexp scope text, frameworks CoreFoundation
 add_library(bundles STATIC)
-file(GLOB _src src/*.cc)
+file(GLOB _src CONFIGURE_DEPENDS src/*.cc)
 target_sources(bundles PRIVATE ${_src})
 textmate_framework(bundles)
 target_link_libraries(bundles PUBLIC OakSystem io plist regexp scope text

--- a/Frameworks/bundles/src/item.cc
+++ b/Frameworks/bundles/src/item.cc
@@ -142,7 +142,7 @@ namespace bundles
 			}
 			else if(pair.first == kFieldRequiredItems && plist::get<plist::array_t>(&pair.second))
 			{
-				for(auto const& dict : plist::get<plist::array_t>(pair.second))
+				for(auto const& dict : *plist::get<plist::array_t>(&pair.second))
 				{
 					std::string name;
 					oak::uuid_t uuid;
@@ -320,7 +320,8 @@ namespace bundles
 		plist::dictionary_t res;
 		for(auto const& pair : plist)
 		{
-			if(!plist::get<bool>(&pair.second) || plist::get<bool>(pair.second))
+			bool const* flag = plist::get<bool>(&pair.second);
+			if(!flag || *flag)
 				res.insert(res.end(), pair);
 		}
 		return res;

--- a/Frameworks/cf/CMakeLists.txt
+++ b/Frameworks/cf/CMakeLists.txt
@@ -1,6 +1,6 @@
 # rave: require text, frameworks CoreFoundation ApplicationServices
 add_library(cf STATIC)
-file(GLOB _src src/*.cc)
+file(GLOB _src CONFIGURE_DEPENDS src/*.cc)
 target_sources(cf PRIVATE ${_src})
 textmate_framework(cf)
 target_link_libraries(cf PUBLIC text "-framework CoreFoundation" "-framework ApplicationServices")

--- a/Frameworks/command/CMakeLists.txt
+++ b/Frameworks/command/CMakeLists.txt
@@ -1,6 +1,6 @@
 # rave: require OakAppKit OakFoundation OakSystem buffer bundles cf io plist regexp scope selection settings text
 add_library(command STATIC)
-file(GLOB _src src/*.cc src/*.mm)
+file(GLOB _src CONFIGURE_DEPENDS src/*.cc src/*.mm)
 target_sources(command PRIVATE ${_src})
 textmate_framework(command)
 target_link_libraries(command PUBLIC

--- a/Frameworks/crash/CMakeLists.txt
+++ b/Frameworks/crash/CMakeLists.txt
@@ -1,5 +1,5 @@
 # rave: no deps
 add_library(crash STATIC)
-file(GLOB _src src/*.cc)
+file(GLOB _src CONFIGURE_DEPENDS src/*.cc)
 target_sources(crash PRIVATE ${_src})
 textmate_framework(crash)

--- a/Frameworks/document/CMakeLists.txt
+++ b/Frameworks/document/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_library(document STATIC)
-file(GLOB _src src/*.mm src/*.cc)
+file(GLOB _src CONFIGURE_DEPENDS src/*.mm src/*.cc)
 target_sources(document PRIVATE ${_src})
 textmate_framework(document)
 target_link_libraries(document PUBLIC

--- a/Frameworks/editor/CMakeLists.txt
+++ b/Frameworks/editor/CMakeLists.txt
@@ -1,6 +1,6 @@
 # rave: require buffer bundles cf command io regexp scope selection settings text
 add_library(editor STATIC)
-file(GLOB _src src/*.cc)
+file(GLOB _src CONFIGURE_DEPENDS src/*.cc)
 target_sources(editor PRIVATE ${_src})
 textmate_framework(editor)
 target_link_libraries(editor PUBLIC buffer bundles cf command io regexp scope selection settings text)

--- a/Frameworks/editor/src/dispatch.cc
+++ b/Frameworks/editor/src/dispatch.cc
@@ -303,7 +303,9 @@ namespace ng
 
 		for(auto const& command : commands)
 		{
-			plist::dictionary_t dict = plist::get<plist::dictionary_t>(command); // TODO ASSERT this!
+			// A malformed entry yields an empty dictionary and is skipped below,
+			// rather than throwing out of the editor mid-macro.
+			plist::dictionary_t dict = plist::convert<plist::dictionary_t>(command);
 			std::string sel, str;
 			plist::dictionary_t args;
 			if(plist::get_key_path(dict, "command", sel))

--- a/Frameworks/editor/tests/t_command.cc
+++ b/Frameworks/editor/tests/t_command.cc
@@ -32,7 +32,7 @@ void test_replace_selection_command ()
 	ng::editor_t editor(buf);
 	editor.insert("to be replaced");
 	editor.perform(ng::kSelectAll);
-	editor.execute_dispatch(plist::get<plist::dictionary_t>(plist::parse(plistSrc)), std::map<std::string, std::string>(), [&editor](bundle_command_t const& cmd, ng::buffer_api_t const& buf, ng::ranges_t const& sel, std::map<std::string, std::string> const& env){
+	editor.execute_dispatch(plist::convert<plist::dictionary_t>(plist::parse(plistSrc)), std::map<std::string, std::string>(), [&editor](bundle_command_t const& cmd, ng::buffer_api_t const& buf, ng::ranges_t const& sel, std::map<std::string, std::string> const& env){
 		command::runner_ptr runner = command::runner(cmd, buf, sel, env, std::make_shared<delegate_t>(editor));
 		runner->launch();
 		runner->wait_for_command();

--- a/Frameworks/editor/tests/t_macro.cc
+++ b/Frameworks/editor/tests/t_macro.cc
@@ -11,7 +11,7 @@ void test_insert ()
 
 	ng::buffer_t buf;
 	ng::editor_t editor(buf);
-	editor.macro_dispatch(plist::get<plist::dictionary_t>(plist::parse(plistSrc)), std::map<std::string, std::string>(), [](bundle_command_t const& cmd, ng::buffer_api_t const& buf, ng::ranges_t const& sel, std::map<std::string, std::string> const& env){
+	editor.macro_dispatch(plist::convert<plist::dictionary_t>(plist::parse(plistSrc)), std::map<std::string, std::string>(), [](bundle_command_t const& cmd, ng::buffer_api_t const& buf, ng::ranges_t const& sel, std::map<std::string, std::string> const& env){
 		OAK_ASSERT(false); // Macro does not contain any commands
 	});
 	OAK_ASSERT_EQ(editor.as_string(), "Test");
@@ -36,7 +36,7 @@ void test_snippet ()
 
 	ng::buffer_t buf;
 	ng::editor_t editor(buf);
-	editor.macro_dispatch(plist::get<plist::dictionary_t>(plist::parse(plistSrc)), std::map<std::string, std::string>(), [](bundle_command_t const& cmd, ng::buffer_api_t const& buf, ng::ranges_t const& sel, std::map<std::string, std::string> const& env){
+	editor.macro_dispatch(plist::convert<plist::dictionary_t>(plist::parse(plistSrc)), std::map<std::string, std::string>(), [](bundle_command_t const& cmd, ng::buffer_api_t const& buf, ng::ranges_t const& sel, std::map<std::string, std::string> const& env){
 		OAK_ASSERT(false); // Macro does not contain any commands
 	});
 	OAK_ASSERT_EQ(editor.as_string(), "2010-01-25");
@@ -77,7 +77,7 @@ void test_command ()
 	ng::buffer_t buf;
 	ng::editor_t editor(buf);
 	editor.insert("to be replaced");
-	editor.macro_dispatch(plist::get<plist::dictionary_t>(plist::parse(plistSrc)), std::map<std::string, std::string>(), [&editor](bundle_command_t const& cmd, ng::buffer_api_t const& buf, ng::ranges_t const& sel, std::map<std::string, std::string> const& env){
+	editor.macro_dispatch(plist::convert<plist::dictionary_t>(plist::parse(plistSrc)), std::map<std::string, std::string>(), [&editor](bundle_command_t const& cmd, ng::buffer_api_t const& buf, ng::ranges_t const& sel, std::map<std::string, std::string> const& env){
 		command::runner_ptr runner = command::runner(cmd, buf, sel, env, std::make_shared<delegate_t>(editor));
 		runner->launch();
 		runner->wait_for_command();

--- a/Frameworks/editor/tests/t_snippets.cc
+++ b/Frameworks/editor/tests/t_snippets.cc
@@ -7,7 +7,7 @@ void test_repopulating_mirrors ()
 	ng::buffer_t buf;
 	ng::editor_t editor(buf);
 
-	editor.snippet_dispatch(plist::get<plist::dictionary_t>(plist::parse(plistSrc)), std::map<std::string, std::string>());
+	editor.snippet_dispatch(plist::convert<plist::dictionary_t>(plist::parse(plistSrc)), std::map<std::string, std::string>());
 	OAK_ASSERT_EQ(editor.as_string(), "-x-");
 	OAK_ASSERT_EQ(to_s(editor.ranges()), "[1-2]");
 

--- a/Frameworks/encoding/CMakeLists.txt
+++ b/Frameworks/encoding/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_library(encoding STATIC)
-file(GLOB _src src/*.mm)
+file(GLOB _src CONFIGURE_DEPENDS src/*.mm)
 target_sources(encoding PRIVATE ${_src})
 textmate_framework(encoding)
 

--- a/Frameworks/file/CMakeLists.txt
+++ b/Frameworks/file/CMakeLists.txt
@@ -1,6 +1,6 @@
 # rave: require authorization bundles cf command encoding io plist regexp scm settings text
 add_library(file STATIC)
-file(GLOB _src src/*.cc src/*.mm)
+file(GLOB _src CONFIGURE_DEPENDS src/*.cc src/*.mm)
 target_sources(file PRIVATE ${_src})
 textmate_framework(file)
 target_link_libraries(file PUBLIC

--- a/Frameworks/io/CMakeLists.txt
+++ b/Frameworks/io/CMakeLists.txt
@@ -1,6 +1,6 @@
 # rave: require text cf ns regexp crash OakFoundation, frameworks Carbon Security
 add_library(io STATIC)
-file(GLOB _src src/*.cc src/*.mm)
+file(GLOB _src CONFIGURE_DEPENDS src/*.cc src/*.mm)
 target_sources(io PRIVATE ${_src})
 textmate_framework(io)
 target_link_libraries(io PUBLIC text cf ns regexp crash OakFoundation

--- a/Frameworks/layout/CMakeLists.txt
+++ b/Frameworks/layout/CMakeLists.txt
@@ -1,6 +1,6 @@
 # rave: require OakFoundation buffer bundles cf crash io ns plist regexp selection text theme
 add_library(layout STATIC)
-file(GLOB _src src/*.cc)
+file(GLOB _src CONFIGURE_DEPENDS src/*.cc)
 target_sources(layout PRIVATE ${_src})
 textmate_framework(layout)
 target_link_libraries(layout PUBLIC

--- a/Frameworks/network/CMakeLists.txt
+++ b/Frameworks/network/CMakeLists.txt
@@ -4,7 +4,7 @@
 # Not present in tectiv3/textmate — they removed the in-app updater and this
 # framework with it. Retained here because SoftwareUpdate depends on it.
 add_library(network STATIC)
-file(GLOB _src src/*.cc src/*.mm)
+file(GLOB _src CONFIGURE_DEPENDS src/*.cc src/*.mm)
 target_sources(network PRIVATE ${_src})
 # Deliberately NOT textmate_framework(network).
 #

--- a/Frameworks/ns/CMakeLists.txt
+++ b/Frameworks/ns/CMakeLists.txt
@@ -1,6 +1,6 @@
 # rave: require text OakFoundation plist
 add_library(ns STATIC)
-file(GLOB _src src/*.mm)
+file(GLOB _src CONFIGURE_DEPENDS src/*.mm)
 target_sources(ns PRIVATE ${_src})
 textmate_framework(ns)
 target_link_libraries(ns PUBLIC text OakFoundation plist "-framework Cocoa")

--- a/Frameworks/parse/CMakeLists.txt
+++ b/Frameworks/parse/CMakeLists.txt
@@ -1,6 +1,6 @@
 # rave: require text bundles plist regexp scope
 add_library(parse STATIC)
-file(GLOB _src src/*.cc)
+file(GLOB _src CONFIGURE_DEPENDS src/*.cc)
 target_sources(parse PRIVATE ${_src})
 textmate_framework(parse)
 target_link_libraries(parse PUBLIC text bundles plist regexp scope)

--- a/Frameworks/parse/src/grammar.cc
+++ b/Frameworks/parse/src/grammar.cc
@@ -55,7 +55,7 @@ namespace parse
 
 		if(plist::dictionary_t const* plist = plist::get<plist::dictionary_t>(&any))
 		{
-			if(!plist->empty() && (plist->find("disabled") == plist->end() || !plist::get<int32_t>(plist->find("disabled")->second)))
+			if(!plist->empty() && (plist->find("disabled") == plist->end() || !plist::convert<int32_t>(plist->find("disabled")->second)))
 			{
 				rule_ptr res = std::make_shared<rule_t>();
 				if(schema.convert(*plist, res.get()))

--- a/Frameworks/plist/CMakeLists.txt
+++ b/Frameworks/plist/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_library(plist STATIC)
-file(GLOB _src src/*.cc src/*.mm)
+file(GLOB _src CONFIGURE_DEPENDS src/*.cc src/*.mm)
 target_sources(plist PRIVATE ${_src})
 textmate_framework(plist)
 target_include_directories(plist PRIVATE

--- a/Frameworks/plist/src/delta.cc
+++ b/Frameworks/plist/src/delta.cc
@@ -61,9 +61,11 @@ static void delta_plist_helper (plist::dictionary_t const& oldDict, plist::dicti
 		newPath.push_back(newValue.first);
 
 		plist::dictionary_t::const_iterator oldValue = oldDict.find(newValue.first);
-		if(::plist::get<plist::dictionary_t>(&newValue.second) && oldValue != oldDict.end() && ::plist::get<plist::dictionary_t>(&oldValue->second))
+		plist::dictionary_t const* newSubDict = ::plist::get<plist::dictionary_t>(&newValue.second);
+		plist::dictionary_t const* oldSubDict = oldValue != oldDict.end() ? ::plist::get<plist::dictionary_t>(&oldValue->second) : nullptr;
+		if(newSubDict && oldSubDict)
 		{
-			delta_plist_helper(::plist::get<plist::dictionary_t>(oldValue->second), ::plist::get<plist::dictionary_t>(newValue.second), changed, deleted, newPath);
+			delta_plist_helper(*oldSubDict, *newSubDict, changed, deleted, newPath);
 		}
 		else if(oldValue == oldDict.end() || !plist::equal(oldValue->second, newValue.second))
 		{

--- a/Frameworks/plist/src/plist.h
+++ b/Frameworks/plist/src/plist.h
@@ -55,9 +55,14 @@ namespace plist
 		bool operator< (any_t const& rhs) const  { return data < rhs.data; }
 	};
 
-	// Drop-in replacements for boost::get
+	// Drop-in replacements for boost::get. These are strict: the stored type
+	// must be exactly T. There is deliberately no overload taking any_t const&
+	// — a const value is nearly always a read that wants plist::convert<T>,
+	// which coerces and yields a default when the types do not line up, the
+	// way plist::get<T> did before any_t moved off boost::variant. Making the
+	// const case a compile error keeps that choice explicit, and avoids
+	// returning a reference into an any_t temporary.
 	template <typename T> T& get (any_t& v)             { return std::get<T>(v.data); }
-	template <typename T> T const& get (any_t const& v)  { return std::get<T>(v.data); }
 	template <typename T> T* get (any_t* v)              { return v ? std::get_if<T>(&v->data) : nullptr; }
 	template <typename T> T const* get (any_t const* v)  { return v ? std::get_if<T>(&v->data) : nullptr; }
 

--- a/Frameworks/plist/src/schema.h
+++ b/Frameworks/plist/src/schema.h
@@ -58,7 +58,7 @@ namespace plist
 			{
 				if(T const* typedValue = ::plist::get<T>(&value))
 						obj->*_field = *typedValue;
-				else	obj->*_field = ::plist::get<T>(value);
+				else	obj->*_field = ::plist::convert<T>(value);
 				return true;
 			}
 
@@ -80,7 +80,7 @@ namespace plist
 			{
 				if(SRC_T const* typedValue = ::plist::get<SRC_T>(&value))
 						return _converter(*typedValue, obj->*_field);
-				else	return _converter(get<SRC_T>(value), obj->*_field);
+				else	return _converter(::plist::convert<SRC_T>(value), obj->*_field);
 			}
 
 			DST_T OBJ_TYPE::* _field;

--- a/Frameworks/plist/tests/t_delta.cc
+++ b/Frameworks/plist/tests/t_delta.cc
@@ -65,9 +65,9 @@ void test_delta ()
 		"	isDelta = :true;\n"
 		"}";
 
-	plist::dictionary_t const oldPlist   = plist::get<plist::dictionary_t>(plist::parse_ascii(oldPlistString));
-	plist::dictionary_t const newPlist   = plist::get<plist::dictionary_t>(plist::parse_ascii(newPlistString));
-	plist::dictionary_t const deltaPlist = plist::get<plist::dictionary_t>(plist::parse_ascii(deltaPlistString));
+	plist::dictionary_t const oldPlist   = plist::convert<plist::dictionary_t>(plist::parse_ascii(oldPlistString));
+	plist::dictionary_t const newPlist   = plist::convert<plist::dictionary_t>(plist::parse_ascii(newPlistString));
+	plist::dictionary_t const deltaPlist = plist::convert<plist::dictionary_t>(plist::parse_ascii(deltaPlistString));
 
 	OAK_ASSERT_EQ(to_s(plist::create_delta(oldPlist, newPlist)), to_s(deltaPlist));
 
@@ -111,9 +111,9 @@ void test_delta_settings_changed ()
 		"	uuid = '73251DBE-EBD2-470F-8148-E6F2EC1A9641';\n"
 		"}\n";
 
-	plist::dictionary_t const oldPlist   = plist::get<plist::dictionary_t>(plist::parse_ascii(oldPlistString));
-	plist::dictionary_t const newPlist   = plist::get<plist::dictionary_t>(plist::parse_ascii(newPlistString));
-	plist::dictionary_t const deltaPlist = plist::get<plist::dictionary_t>(plist::parse_ascii(deltaPlistString));
+	plist::dictionary_t const oldPlist   = plist::convert<plist::dictionary_t>(plist::parse_ascii(oldPlistString));
+	plist::dictionary_t const newPlist   = plist::convert<plist::dictionary_t>(plist::parse_ascii(newPlistString));
+	plist::dictionary_t const deltaPlist = plist::convert<plist::dictionary_t>(plist::parse_ascii(deltaPlistString));
 
 	std::vector<plist::dictionary_t> plists{ deltaPlist, oldPlist };
 	OAK_ASSERT_EQ(to_s(plist::merge_delta(plists)), to_s(newPlist));
@@ -141,9 +141,9 @@ void test_delta_settings_deleted ()
 		"	uuid = '20881CB9-5D12-4D74-8EE6-9ABAA7B408D3';\n"
 		"}\n";
 
-	plist::dictionary_t const oldPlist   = plist::get<plist::dictionary_t>(plist::parse_ascii(oldPlistString));
-	plist::dictionary_t const newPlist   = plist::get<plist::dictionary_t>(plist::parse_ascii(newPlistString));
-	plist::dictionary_t const deltaPlist = plist::get<plist::dictionary_t>(plist::parse_ascii(deltaPlistString));
+	plist::dictionary_t const oldPlist   = plist::convert<plist::dictionary_t>(plist::parse_ascii(oldPlistString));
+	plist::dictionary_t const newPlist   = plist::convert<plist::dictionary_t>(plist::parse_ascii(newPlistString));
+	plist::dictionary_t const deltaPlist = plist::convert<plist::dictionary_t>(plist::parse_ascii(deltaPlistString));
 
 	std::vector<plist::dictionary_t> plists{ deltaPlist, oldPlist };
 	OAK_ASSERT_EQ(to_s(plist::merge_delta(plists)), to_s(newPlist));
@@ -178,9 +178,9 @@ void test_delta_keys_with_dots ()
 		"	};\n"
 		"}\n";
 
-	plist::dictionary_t const oldPlist   = plist::get<plist::dictionary_t>(plist::parse_ascii(oldPlistString));
-	plist::dictionary_t const newPlist   = plist::get<plist::dictionary_t>(plist::parse_ascii(newPlistString));
-	plist::dictionary_t const deltaPlist = plist::get<plist::dictionary_t>(plist::parse_ascii(deltaPlistString));
+	plist::dictionary_t const oldPlist   = plist::convert<plist::dictionary_t>(plist::parse_ascii(oldPlistString));
+	plist::dictionary_t const newPlist   = plist::convert<plist::dictionary_t>(plist::parse_ascii(newPlistString));
+	plist::dictionary_t const deltaPlist = plist::convert<plist::dictionary_t>(plist::parse_ascii(deltaPlistString));
 
 	OAK_ASSERT_EQ(to_s(plist::create_delta(oldPlist, newPlist)), to_s(deltaPlist));
 

--- a/Frameworks/plist/tests/t_schema.cc
+++ b/Frameworks/plist/tests/t_schema.cc
@@ -1,0 +1,72 @@
+#include <plist/schema.h>
+
+// A plist reaching a schema is arbitrary user data: nothing has validated that
+// each key holds the type the schema maps it to. Grammars and themes in the
+// wild do carry a numeric `name` or a string `disabled`, and TextMate has
+// always coerced those rather than rejecting the whole file.
+//
+// The coercion lives in plist::convert<T>. Reading the value with
+// plist::get<T> instead throws std::bad_variant_access, which in a release
+// build escapes NSApplicationMain and aborts the application as it opens a
+// document. These fixtures build the mismatched types directly, because the
+// ASCII plist parser reads every unquoted token as a string and so cannot
+// produce them; the real ones arrive from XML and binary plists via
+// CFPropertyList.
+
+struct record_t
+{
+	std::string name;
+	std::string content;
+	int32_t disabled = -1;
+	bool flag = false;
+};
+
+static plist::schema_t<record_t> const& record_schema ()
+{
+	static plist::schema_t<record_t> schema = plist::schema_t<record_t>()
+		.map("name",     &record_t::name)
+		.map("content",  &record_t::content)
+		.map("disabled", &record_t::disabled)
+		.map("flag",     &record_t::flag)
+	;
+	return schema;
+}
+
+void test_schema_reads_matching_types ()
+{
+	plist::dictionary_t dict;
+	dict["name"]     = std::string("example");
+	dict["disabled"] = int32_t(1);
+	dict["flag"]     = true;
+
+	record_t rec;
+	OAK_ASSERT(record_schema().convert(dict, &rec));
+	OAK_ASSERT_EQ(rec.name, "example");
+	OAK_ASSERT_EQ(rec.disabled, 1);
+	OAK_ASSERT_EQ(rec.flag, true);
+}
+
+void test_schema_coerces_mismatched_types ()
+{
+	plist::dictionary_t dict;
+	dict["name"]     = int32_t(42);            // schema wants a string
+	dict["content"]  = true;                   // schema wants a string
+	dict["disabled"] = std::string("no");      // schema wants an int32_t
+
+	record_t rec;
+	OAK_ASSERT(record_schema().convert(dict, &rec));
+	OAK_ASSERT_EQ(rec.disabled, 0);
+}
+
+void test_schema_coerces_container_mismatch ()
+{
+	// A container where a scalar is expected has no sensible coercion, so the
+	// field is left default-constructed. It must still not throw.
+	plist::dictionary_t dict;
+	dict["name"] = plist::array_t{ plist::any_t(std::string("a")) };
+
+	record_t rec;
+	rec.name = "untouched";
+	OAK_ASSERT(record_schema().convert(dict, &rec));
+	OAK_ASSERT_EQ(rec.name, "");
+}

--- a/Frameworks/plist/tests/t_simple.cc
+++ b/Frameworks/plist/tests/t_simple.cc
@@ -89,8 +89,8 @@ void test_bool ()
 	plist::any_t mixedPlist = plist::parse_ascii("( :true, :false )");
 	OAK_ASSERT(plist::get< std::vector<plist::any_t> >(&mixedPlist));
 	std::vector<plist::any_t> const& v = plist::get< std::vector<plist::any_t> >(mixedPlist);
-	OAK_ASSERT_EQ(plist::get<bool>(v[0]), true);
-	OAK_ASSERT_EQ(plist::get<bool>(v[1]), false);
+	OAK_ASSERT_EQ(plist::convert<bool>(v[0]), true);
+	OAK_ASSERT_EQ(plist::convert<bool>(v[1]), false);
 
 	// plist::any_t badPlist = plist::parse_ascii(":bad");
 	// OAK_ASSERT_EQ(plist::get<bool>(&badPlist), (bool*)nullptr);
@@ -216,23 +216,23 @@ void test_number_type ()
 
 void test_number_conversion ()
 {
-	OAK_ASSERT_EQ(plist::get<int32_t>(plist::parse_ascii(  "+32")),       32);
-	OAK_ASSERT_EQ(plist::get<int32_t>(plist::parse_ascii(   "32")),       32);
-	OAK_ASSERT_EQ(plist::get<int32_t>(plist::parse_ascii(  "-32")),      -32);
-	OAK_ASSERT_EQ(plist::get<int32_t>(plist::parse_ascii("+0x32")),     0x32);
-	OAK_ASSERT_EQ(plist::get<int32_t>(plist::parse_ascii( "0x32")),     0x32);
-	OAK_ASSERT_EQ(plist::get<int32_t>(plist::parse_ascii("-0x32")),    -0x32);
-	OAK_ASSERT_EQ(plist::get<int32_t>(plist::parse_ascii(   "07")),        7);
-	OAK_ASSERT_EQ(plist::get<int32_t>(plist::parse_ascii( "+010")),        8);
-	OAK_ASSERT_EQ(plist::get<int32_t>(plist::parse_ascii(  "010")),        8);
-	OAK_ASSERT_EQ(plist::get<int32_t>(plist::parse_ascii(  "-07")),       -7);
-	OAK_ASSERT_EQ(plist::get<int32_t>(plist::parse_ascii( "-010")),       -8);
+	OAK_ASSERT_EQ(plist::convert<int32_t>(plist::parse_ascii(  "+32")),       32);
+	OAK_ASSERT_EQ(plist::convert<int32_t>(plist::parse_ascii(   "32")),       32);
+	OAK_ASSERT_EQ(plist::convert<int32_t>(plist::parse_ascii(  "-32")),      -32);
+	OAK_ASSERT_EQ(plist::convert<int32_t>(plist::parse_ascii("+0x32")),     0x32);
+	OAK_ASSERT_EQ(plist::convert<int32_t>(plist::parse_ascii( "0x32")),     0x32);
+	OAK_ASSERT_EQ(plist::convert<int32_t>(plist::parse_ascii("-0x32")),    -0x32);
+	OAK_ASSERT_EQ(plist::convert<int32_t>(plist::parse_ascii(   "07")),        7);
+	OAK_ASSERT_EQ(plist::convert<int32_t>(plist::parse_ascii( "+010")),        8);
+	OAK_ASSERT_EQ(plist::convert<int32_t>(plist::parse_ascii(  "010")),        8);
+	OAK_ASSERT_EQ(plist::convert<int32_t>(plist::parse_ascii(  "-07")),       -7);
+	OAK_ASSERT_EQ(plist::convert<int32_t>(plist::parse_ascii( "-010")),       -8);
 }
 
 void test_uint64_conversion ()
 {
-	OAK_ASSERT_EQ(plist::get<uint64_t>(plist::parse_ascii("8589934592")),     8589934592ULL);
-	OAK_ASSERT_EQ(plist::get<uint64_t>(plist::parse_ascii("0x812345678")),   0x812345678ULL);
+	OAK_ASSERT_EQ(plist::convert<uint64_t>(plist::parse_ascii("8589934592")),     8589934592ULL);
+	OAK_ASSERT_EQ(plist::convert<uint64_t>(plist::parse_ascii("0x812345678")),   0x812345678ULL);
 	OAK_ASSERT_EQ(plist::convert<uint64_t>(plist::parse_ascii("'0x812345678'")), 0x812345678ULL);
 }
 

--- a/Frameworks/regexp/CMakeLists.txt
+++ b/Frameworks/regexp/CMakeLists.txt
@@ -1,6 +1,6 @@
 # rave: require Onigmo text cf
 add_library(regexp STATIC)
-file(GLOB _src src/*.cc)
+file(GLOB _src CONFIGURE_DEPENDS src/*.cc)
 target_sources(regexp PRIVATE ${_src})
 textmate_framework(regexp)
 target_link_libraries(regexp PUBLIC Onigmo text cf)

--- a/Frameworks/scm/CMakeLists.txt
+++ b/Frameworks/scm/CMakeLists.txt
@@ -1,13 +1,13 @@
 # rave: require text cf io settings regexp, sources src/**/*.cc, frameworks Carbon Security
 add_library(scm STATIC)
-file(GLOB_RECURSE _src CONFIGURE_DEPENDS src/*.cc)
+file(GLOB_RECURSE _src CONFIGURE_DEPENDS CONFIGURE_DEPENDS src/*.cc)
 target_sources(scm PRIVATE ${_src})
 textmate_framework(scm)
 target_link_libraries(scm PUBLIC text cf io settings regexp xdiff
   "-framework Carbon" "-framework Security")
 
 # Resources
-file(GLOB _resources resources/*)
+file(GLOB _resources CONFIGURE_DEPENDS resources/*)
 if(_resources)
   target_sources(scm PRIVATE ${_resources})
 endif()

--- a/Frameworks/scope/CMakeLists.txt
+++ b/Frameworks/scope/CMakeLists.txt
@@ -1,6 +1,6 @@
 # rave: require text
 add_library(scope STATIC)
-file(GLOB _src src/*.cc)
+file(GLOB _src CONFIGURE_DEPENDS src/*.cc)
 target_sources(scope PRIVATE ${_src})
 textmate_framework(scope)
 target_link_libraries(scope PUBLIC text)

--- a/Frameworks/selection/CMakeLists.txt
+++ b/Frameworks/selection/CMakeLists.txt
@@ -1,6 +1,6 @@
 # rave: require text buffer bundles crash regexp
 add_library(selection STATIC)
-file(GLOB _src src/*.cc)
+file(GLOB _src CONFIGURE_DEPENDS src/*.cc)
 target_sources(selection PRIVATE ${_src})
 textmate_framework(selection)
 target_link_libraries(selection PUBLIC text buffer bundles crash regexp)

--- a/Frameworks/settings/CMakeLists.txt
+++ b/Frameworks/settings/CMakeLists.txt
@@ -1,6 +1,6 @@
 # rave: require cf io plist regexp scope text
 add_library(settings STATIC)
-file(GLOB _src src/*.cc)
+file(GLOB _src CONFIGURE_DEPENDS src/*.cc)
 target_sources(settings PRIVATE ${_src})
 textmate_framework(settings)
 target_link_libraries(settings PUBLIC cf io plist regexp scope text)

--- a/Frameworks/text/CMakeLists.txt
+++ b/Frameworks/text/CMakeLists.txt
@@ -1,6 +1,6 @@
 # rave: require (none), headers src/*.h, sources src/*.cc, tests, frameworks CoreFoundation, libraries iconv
 add_library(text STATIC)
-file(GLOB _src src/*.cc)
+file(GLOB _src CONFIGURE_DEPENDS src/*.cc)
 target_sources(text PRIVATE ${_src})
 textmate_framework(text)
 target_link_libraries(text PUBLIC "-framework CoreFoundation")

--- a/Frameworks/theme/CMakeLists.txt
+++ b/Frameworks/theme/CMakeLists.txt
@@ -1,6 +1,6 @@
 # rave: require bundles cf ns scope
 add_library(theme STATIC)
-file(GLOB _src src/*.cc src/*.mm)
+file(GLOB _src CONFIGURE_DEPENDS src/*.cc src/*.mm)
 target_sources(theme PRIVATE ${_src})
 textmate_framework(theme)
 target_link_libraries(theme PUBLIC bundles cf ns scope)

--- a/Frameworks/theme/src/OakTheme.mm
+++ b/Frameworks/theme/src/OakTheme.mm
@@ -175,7 +175,7 @@ static CGFloat ParseFontSize (NSString* fontSizeString)
 {
 	bundles::item_ptr item;
 	plist::any_t const value = bundles::value_for_setting(to_s(key), scope, &item);
-	return item ? to_ns(plist::get<std::string>(value)) : nil;
+	return item ? to_ns(plist::convert<std::string>(value)) : nil;
 }
 
 - (NSString*)description

--- a/Frameworks/theme/src/theme.cc
+++ b/Frameworks/theme/src/theme.cc
@@ -112,7 +112,7 @@ std::vector<theme_t::decomposed_style_t> theme_t::global_styles (scope::scope_t 
 		if(item)
 		{
 			res.emplace_back(item->scope_selector());
-			res.back().*(colorKey.field) = read_color(plist::get<std::string>(value));
+			res.back().*(colorKey.field) = read_color(plist::convert<std::string>(value));
 		}
 	}
 
@@ -132,7 +132,7 @@ std::vector<theme_t::decomposed_style_t> theme_t::global_styles (scope::scope_t 
 	if(fontNameItem)
 	{
 		res.emplace_back(fontNameItem->scope_selector());
-		res.back().font_name = plist::get<std::string>(fontNameValue);
+		res.back().font_name = plist::convert<std::string>(fontNameValue);
 	}
 
 	bundles::item_ptr fontSizeItem;
@@ -140,7 +140,7 @@ std::vector<theme_t::decomposed_style_t> theme_t::global_styles (scope::scope_t 
 	if(fontSizeItem)
 	{
 		res.emplace_back(fontSizeItem->scope_selector());
-		res.back().font_size = read_font_size(plist::get<std::string>(fontSizeValue));
+		res.back().font_size = read_font_size(plist::convert<std::string>(fontSizeValue));
 	}
 
 	return res;

--- a/Frameworks/undo/CMakeLists.txt
+++ b/Frameworks/undo/CMakeLists.txt
@@ -1,6 +1,6 @@
 # rave: require buffer selection
 add_library(undo STATIC)
-file(GLOB _src src/*.cc)
+file(GLOB _src CONFIGURE_DEPENDS src/*.cc)
 target_sources(undo PRIVATE ${_src})
 textmate_framework(undo)
 target_link_libraries(undo PUBLIC buffer selection)

--- a/Shared/include/test/bundle_index.h
+++ b/Shared/include/test/bundle_index.h
@@ -28,7 +28,7 @@ namespace test
 
 		bundles::item_ptr add (bundles::kind_t itemKind, std::string const& plistString)
 		{
-			return add(itemKind, plist::get<plist::dictionary_t>(plist::parse_ascii(plistString)));
+			return add(itemKind, plist::convert<plist::dictionary_t>(plist::parse_ascii(plistString)));
 		}
 
 		bool commit () const

--- a/cmake/TextMateHelpers.cmake
+++ b/cmake/TextMateHelpers.cmake
@@ -48,7 +48,7 @@ endfunction()
 
 # Asset catalog compilation (.xcassets → .car via actool)
 function(target_asset_catalog TARGET XCASSETS_DIR)
-  file(GLOB_RECURSE _assets "${CMAKE_CURRENT_SOURCE_DIR}/${XCASSETS_DIR}/*")
+  file(GLOB_RECURSE _assets CONFIGURE_DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/${XCASSETS_DIR}/*")
   set(_car "${CMAKE_CURRENT_BINARY_DIR}/Assets.car")
   add_custom_command(
     OUTPUT "${_car}"
@@ -124,7 +124,7 @@ function(textmate_add_tests FRAMEWORK_TARGET)
   if(NOT BUILD_TESTING)
     return()
   endif()
-  file(GLOB _test_sources
+  file(GLOB _test_sources CONFIGURE_DEPENDS
     "${CMAKE_CURRENT_SOURCE_DIR}/tests/t_*.cc"
     "${CMAKE_CURRENT_SOURCE_DIR}/tests/t_*.mm")
   if(NOT _test_sources)
@@ -134,7 +134,7 @@ function(textmate_add_tests FRAMEWORK_TARGET)
   set(_test_target "${FRAMEWORK_TARGET}_tests")
 
   # Use .mm extension when any test source is ObjC++ so runner compiles correctly
-  file(GLOB _mm_tests "${CMAKE_CURRENT_SOURCE_DIR}/tests/t_*.mm")
+  file(GLOB _mm_tests CONFIGURE_DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/tests/t_*.mm")
   if(_mm_tests)
     set(_runner "${CMAKE_CURRENT_BINARY_DIR}/test_runner.mm")
     # rave ran every ObjC++ suite with --no-parallel, and bin/gen_test's serial

--- a/vendor/Onigmo/CMakeLists.txt
+++ b/vendor/Onigmo/CMakeLists.txt
@@ -1,14 +1,14 @@
 add_library(Onigmo STATIC)
 
-file(GLOB _src src/*.c)
-file(GLOB _enc
+file(GLOB _src CONFIGURE_DEPENDS src/*.c)
+file(GLOB _enc CONFIGURE_DEPENDS
   vendor/enc/ascii.c
   vendor/enc/euc_jp.c
   vendor/enc/iso8859_1.c
   vendor/enc/sjis.c
   vendor/enc/unicode.c
   vendor/enc/utf*.c)
-file(GLOB _vendor vendor/reg*.c vendor/st.c)
+file(GLOB _vendor CONFIGURE_DEPENDS vendor/reg*.c vendor/st.c)
 
 target_sources(Onigmo PRIVATE ${_src} ${_enc} ${_vendor})
 

--- a/vendor/kvdb/CMakeLists.txt
+++ b/vendor/kvdb/CMakeLists.txt
@@ -1,6 +1,6 @@
 add_library(kvdb STATIC)
 
-file(GLOB _src vendor/kvdb/*.m)
+file(GLOB _src CONFIGURE_DEPENDS vendor/kvdb/*.m)
 target_sources(kvdb PRIVATE ${_src})
 
 # kvdb exports vendor/kvdb/kvdb.h — include parent so <kvdb/kvdb.h> works

--- a/vendor/xdiff/CMakeLists.txt
+++ b/vendor/xdiff/CMakeLists.txt
@@ -1,6 +1,6 @@
 add_library(xdiff STATIC)
 
-file(GLOB _src src/*.c)
+file(GLOB _src CONFIGURE_DEPENDS src/*.c)
 target_sources(xdiff PRIVATE ${_src})
 
 # This tree includes it as <xdiff/xdiff.h> (rave's convention), where tectiv3


### PR DESCRIPTION
The build from `main` aborts on launch:

```
Exception Type:  EXC_CRASH (SIGABRT)
Thread 0 Crashed:
2   libsystem_c.dylib   abort + 148
3   TextMate            main + 896
```

`main()` catches `std::exception` escaping `NSApplicationMain` and calls `abort()`. Under lldb the exception is `std::bad_variant_access`, thrown from `plist::schema_t<parse::rule_t>::variant_field_t::handle` while `parse::grammar_t` reads a grammar during session restore.

## Cause

Nothing validates a plist before it reaches a schema, and grammars and themes in the wild carry keys whose types don't match what the schema maps them to — a numeric `name`, a string `disabled`. TextMate has always coerced those rather than rejecting the file.

The coercion lived in `plist::get<T>(any_t const&)`, which ran a converting visitor and yielded a default when no conversion applied. Its `ASSERT` was debug-only, so release builds carried on:

```cpp
template <typename T> T get (plist::any_t const& from)
{
    T to;
    bool res DB_VAR = boost::apply_visitor(convert_to_helper_t<T>(to), from);
    ASSERT(res);
    return to;
}
```

Moving `any_t` off `boost::variant` (in "Remove boost, google-sparsehash and ragel build dependencies") renamed that function to `plist::convert<T>` and handed the name `plist::get<T>` to the strict, `boost::get`-compatible accessors. Call sites relying on the lenient behaviour kept the old spelling and silently became strict — so a mismatch that used to coerce now throws.

This restores `plist::convert<T>` at each of them: the two schema field handlers, theme colour and font reads, and the `disabled` check in `parse::convert_plist`.

## Two related repairs

Both fall out of the same rename:

- **The strict overload taking `any_t const&` is removed.** Every read of a const `any_t` wants `convert<T>`, and returning a reference into an `any_t` temporary — which several tests did, via `plist::parse_ascii(...)` — is a dangling reference. Making the const case a compile error forces the choice to be explicit. Sites that genuinely need strict access take the pointer overload and check for null, which is the boost idiom anyway. Removing it immediately surfaced four more call sites.
- **`delta.cc` and `item.cc`** re-read a value strictly having already proved its type with the pointer form. They now reuse that pointer.

## Regression test

`Frameworks/plist/tests/t_schema.cc` builds the mismatched types directly, because the ASCII plist parser reads every unquoted token as a string and so cannot produce them — the real ones arrive from XML and binary plists through `CFPropertyList`. My first attempt went through `parse_ascii` and passed against the broken code, which is why the test is written at this level.

Reverting the schema change alone fails it:

```
plist_tests: 2 of 36 tests failed:
bad_variant_access
bad_variant_access
```

## Second commit: globs

While writing that test I found it wasn't running. `file(GLOB)` runs once at configure time, and nothing rechecks it, so a new test file is not compiled into the runner and the suite reports success without it — the suite passes because the test isn't there. rave regenerated its ninja file whenever a watched directory changed.

`CONFIGURE_DEPENDS` on all 75 globs makes ninja recheck them and re-run cmake when the matches change.

## Verification

Clean configure and build, full CTest run: the same six suites fail as before (`cf`, `io`, `buffer`, `scm`, `file`, `network`), all environmental and failing identically under rave. No new failures. The built app launches and restores the session without crashing.