### PR TITLE
Centre tab titles and close buttons in the tab bar

### DIFF
--- a/Frameworks/OakTabBarView/src/OakTabBarView.mm
+++ b/Frameworks/OakTabBarView/src/OakTabBarView.mm
@@ -301,8 +301,15 @@ static void* kOakTabViewSelectedContext  = &kOakTabViewSelectedContext;
 		[self addConstraints:_overflowButtonConstraints];
 
 		[self addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"H:[overflow]|" options:0 metrics:nil views:views]];
-		[self addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"V:[close]-(4)-|" options:0 metrics:nil views:views]];
-		[self addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"V:[title]-(3)-|" options:0 metrics:nil views:views]];
+		// Centred rather than inset from the bottom. The old 4pt and 3pt insets
+		// only centre when the tab is the 22pt that intrinsicContentSize below
+		// implies, and the titlebar accessory renders it about half again as
+		// tall, which left both sitting well under the middle. centerY holds at
+		// whatever height AppKit gives us. The nudge sits them a point below
+		// dead centre, which is where they look right.
+		CGFloat const baselineNudge = 1;
+		[self addConstraint:[NSLayoutConstraint constraintWithItem:self.closeButton attribute:NSLayoutAttributeCenterY relatedBy:NSLayoutRelationEqual toItem:self attribute:NSLayoutAttributeCenterY multiplier:1 constant:baselineNudge]];
+		[self addConstraint:[NSLayoutConstraint constraintWithItem:_textField attribute:NSLayoutAttributeCenterY relatedBy:NSLayoutRelationEqual toItem:self attribute:NSLayoutAttributeCenterY multiplier:1 constant:baselineNudge]];
 		[self addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"V:|[overflow]|" options:0 metrics:nil views:views]];
 
 		[_textField setContentHuggingPriority:NSLayoutPriorityRequired forOrientation:NSLayoutConstraintOrientationHorizontal];


### PR DESCRIPTION
Closes #37.

## The bug

The tab title and close button were positioned by pinning their bottom edges 3pt and 4pt above the bottom of the tab:

```objc
[self addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"V:[close]-(4)-|" ...]];
[self addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"V:[title]-(3)-|" ...]];
```

Those insets centre a 16pt label and a 13pt button only when the tab is 22pt tall, which is what `OakTabBarView.mm:720`'s `intrinsicContentSize` asks for.

It never gets 22pt. The tab bar is an `NSTitlebarAccessoryViewController` view (`DocumentWindowController.mm:208-212`), and AppKit fixes those at a height of its own choosing. Probing it on macOS 26.5 (25F71):

```
requested intrinsic height -> actual
    10 -> 36.0        36 -> 36.0
    23 -> 36.0        60 -> 36.0
```

The request is discarded entirely — it is neither a floor nor a ceiling. No window configuration moves it either: `titlebarAppearsTransparent`, `titleVisibility`, `NSWindowStyleMaskFullSizeContentView`, and both unified toolbar styles all give 36. Only `layoutAttribute` Right or Left differ (32pt), and those place the accessory inline beside the window title, which is no use for a tab bar.

So the accessory is 36pt, tabs fill it at 35pt (`NSHeight(self.bounds)-1`), and the two bottom-pinned subviews sat well below the middle of them.

## Measurements

Clear space above and below the title ink, in device pixels, in a 70px tab, taken from window captures at 2x:

| | above | below |
| --- | --- | --- |
| before | 38 | 7 |
| after | 26 | 25 |

The close button measures 28/28 after the change. Both figures land within a pixel of tagliala's build, which is the reference the issue points at.

## The change

Both subviews are constrained to the tab's centre, which holds at whatever height AppKit hands us, with a 1pt constant so they sit fractionally low rather than dead centre — that reads better at this tab height.

## Relationship to the upstream PRs

The issue links two PRs on tagliala's fork.

- [tagliala#25](https://github.com/tagliala/textmate/pull/25) (merged there) is the same approach as this. Its diff does not apply here: it deletes `V:[close]-(10)-|` and `V:[title]-(9)-|`, values that fork introduced as a workaround with a TODO admitting as much. This tree still has the original 4 and 3.
- [tagliala#16](https://github.com/tagliala/textmate/pull/16) (still open there) removes the `±1` in `setCurrentLayout`'s frame arithmetic. It does not touch the pinning, so it does not address the cause; applied on its own here it moves the title 0.5pt further from centre and the close button 1pt. Not taken.

## Worth noting separately

`intrinsicContentSize` returning 23 has no effect on the rendered height and will mislead the next person to read it. tagliala's [issue #15](https://github.com/tagliala/textmate/issues/15) ("the tab navigation bar is too tall") is unfixable from that direction for the same reason — they observed that changing `intrinsicContentSize` did nothing, and this is why. Left alone here to keep the change to the reported bug.
