### PR TITLE
Replace ruby18 shebangs with the system ruby

### DIFF
--- a/Applications/TextMate/support/Bundles/Avian.tmbundle/Commands/Compress Selected Items.tmCommand
+++ b/Applications/TextMate/support/Bundles/Avian.tmbundle/Commands/Compress Selected Items.tmCommand
@@ -5,7 +5,7 @@
 	<key>beforeRunningCommand</key>
 	<string>nop</string>
 	<key>command</key>
-	<string>#!/usr/bin/env ruby18 -wKU
+	<string>#!/usr/bin/env ruby -wKU
 require "shellwords"
 
 abort "Select one or more items in file browser" unless ENV.has_key? 'TM_SELECTED_FILES'

--- a/Applications/TextMate/support/Bundles/Avian.tmbundle/Commands/Compress Selected Items.tmCommand
+++ b/Applications/TextMate/support/Bundles/Avian.tmbundle/Commands/Compress Selected Items.tmCommand
@@ -5,7 +5,7 @@
 	<key>beforeRunningCommand</key>
 	<string>nop</string>
 	<key>command</key>
-	<string>#!/usr/bin/env ruby -wKU
+	<string>#!/usr/bin/env ruby -wEutf-8
 require "shellwords"
 
 abort "Select one or more items in file browser" unless ENV.has_key? 'TM_SELECTED_FILES'

--- a/Applications/TextMate/support/Bundles/Avian.tmbundle/Commands/Decrypt.tmCommand
+++ b/Applications/TextMate/support/Bundles/Avian.tmbundle/Commands/Decrypt.tmCommand
@@ -5,7 +5,7 @@
 	<key>beforeRunningCommand</key>
 	<string>nop</string>
 	<key>command</key>
-	<string>#!/usr/bin/env ruby18 -wKU
+	<string>#!/usr/bin/env ruby -wKU
 require "#{ENV['TM_SUPPORT_PATH']}/lib/ui.rb"
 require "shellwords"
 

--- a/Applications/TextMate/support/Bundles/Avian.tmbundle/Commands/Decrypt.tmCommand
+++ b/Applications/TextMate/support/Bundles/Avian.tmbundle/Commands/Decrypt.tmCommand
@@ -5,7 +5,7 @@
 	<key>beforeRunningCommand</key>
 	<string>nop</string>
 	<key>command</key>
-	<string>#!/usr/bin/env ruby -wKU
+	<string>#!/usr/bin/env ruby -wEutf-8
 require "#{ENV['TM_SUPPORT_PATH']}/lib/ui.rb"
 require "shellwords"
 

--- a/Applications/TextMate/support/Bundles/Avian.tmbundle/Commands/Encrypt on Save.tmCommand
+++ b/Applications/TextMate/support/Bundles/Avian.tmbundle/Commands/Encrypt on Save.tmCommand
@@ -5,7 +5,7 @@
 	<key>beforeRunningCommand</key>
 	<string>nop</string>
 	<key>command</key>
-	<string>#!/usr/bin/env ruby18 -wKU
+	<string>#!/usr/bin/env ruby -wKU
 require "#{ENV['TM_SUPPORT_PATH']}/lib/ui.rb"
 require "shellwords"
 

--- a/Applications/TextMate/support/Bundles/Avian.tmbundle/Commands/Encrypt on Save.tmCommand
+++ b/Applications/TextMate/support/Bundles/Avian.tmbundle/Commands/Encrypt on Save.tmCommand
@@ -5,7 +5,7 @@
 	<key>beforeRunningCommand</key>
 	<string>nop</string>
 	<key>command</key>
-	<string>#!/usr/bin/env ruby -wKU
+	<string>#!/usr/bin/env ruby -wEutf-8
 require "#{ENV['TM_SUPPORT_PATH']}/lib/ui.rb"
 require "shellwords"
 

--- a/Applications/TextMate/support/Bundles/Avian.tmbundle/Commands/Show Images.tmCommand
+++ b/Applications/TextMate/support/Bundles/Avian.tmbundle/Commands/Show Images.tmCommand
@@ -5,7 +5,7 @@
 	<key>beforeRunningCommand</key>
 	<string>nop</string>
 	<key>command</key>
-	<string>#!/usr/bin/env ruby18 -wKU
+	<string>#!/usr/bin/env ruby -wKU
 require "#{ENV['TM_SUPPORT_PATH']}/lib/escape.rb"
 require "shellwords"
 

--- a/Applications/TextMate/support/Bundles/Avian.tmbundle/Commands/Show Images.tmCommand
+++ b/Applications/TextMate/support/Bundles/Avian.tmbundle/Commands/Show Images.tmCommand
@@ -5,7 +5,7 @@
 	<key>beforeRunningCommand</key>
 	<string>nop</string>
 	<key>command</key>
-	<string>#!/usr/bin/env ruby -wKU
+	<string>#!/usr/bin/env ruby -wEutf-8
 require "#{ENV['TM_SUPPORT_PATH']}/lib/escape.rb"
 require "shellwords"
 

--- a/Frameworks/BundleEditor/templates/Command.plist
+++ b/Frameworks/BundleEditor/templates/Command.plist
@@ -1,2 +1,2 @@
-{	command = '#!/usr/bin/env ruby18 -wKU\nputs "Hello world"\n';
+{	command = '#!/usr/bin/env ruby -wKU\nputs "Hello world"\n';
 }

--- a/Frameworks/BundleEditor/templates/Command.plist
+++ b/Frameworks/BundleEditor/templates/Command.plist
@@ -1,2 +1,2 @@
-{	command = '#!/usr/bin/env ruby -wKU\nputs "Hello world"\n';
+{	command = '#!/usr/bin/env ruby -wEutf-8\nputs "Hello world"\n';
 }

--- a/Frameworks/BundleEditor/templates/Drag Command.plist
+++ b/Frameworks/BundleEditor/templates/Drag Command.plist
@@ -1,4 +1,4 @@
 {	draggedFileExtensions = ( txt );
-	command = '#!/usr/bin/env ruby18 -wKU\nputs "» #{ENV[\'TM_DROPPED_FILE\']}"\n';
+	command = '#!/usr/bin/env ruby -wKU\nputs "» #{ENV[\'TM_DROPPED_FILE\']}"\n';
 	output = insertAsSnippet;
 }

--- a/Frameworks/BundleEditor/templates/Drag Command.plist
+++ b/Frameworks/BundleEditor/templates/Drag Command.plist
@@ -1,4 +1,4 @@
 {	draggedFileExtensions = ( txt );
-	command = '#!/usr/bin/env ruby -wKU\nputs "» #{ENV[\'TM_DROPPED_FILE\']}"\n';
+	command = '#!/usr/bin/env ruby -wEutf-8\nputs "» #{ENV[\'TM_DROPPED_FILE\']}"\n';
 	output = insertAsSnippet;
 }

--- a/bin/show_log
+++ b/bin/show_log
@@ -1,4 +1,4 @@
-#!/usr/bin/env ruby -wKU
+#!/usr/bin/env ruby -wEutf-8
 require 'pathname'
 
 def pretty(txt, width, indent)


### PR DESCRIPTION
macOS has no `ruby18`. On macOS 26.5 `/usr/bin/ruby` is 2.6.10 and nothing named `ruby18` is on PATH, so every command carrying that shebang dies at exec with `env: ruby18: No such file or directory` (exit 127).

Two sites in this repo:

- **`Avian.tmbundle`** (4 commands) — shipped in `Contents/SharedSupport/Bundles` and has no upstream repo of its own, so it is fixed in place.
- **The Bundle Editor templates** (`Frameworks/BundleEditor/templates/Command.plist`, `Drag Command.plist`) — these were minting a `ruby18` shebang into *every* newly created command and drag command, so the problem kept regenerating itself.

`Applications/TextMate/support/Bundles/Source.tmbundle` carries the same shebang but is deliberately left alone here: it is vendored by `bin/fetch_embedded_bundles.sh` at the SHA pinned in `Frameworks/BundlesManager/src/MandatoryBundles.h`, and hand-editing it would desync the `.sha` marker. It follows once textmatelives/source.tmbundle#1 merges and the pin is bumped.

The other 15 bundle repos are covered by companion PRs (48 files total).

Refs textmatelives/textmate#45