### PR TITLE
Give commands a UTF-8 locale

### DIFF
--- a/Frameworks/io/src/environment.cc
+++ b/Frameworks/io/src/environment.cc
@@ -57,6 +57,19 @@ namespace oak
 		res.emplace("LOGNAME", entry->pw_name);
 		res.emplace("USER",    entry->pw_name);
 
+		// Launched from Finder we inherit no locale, which leaves anything we
+		// run defaulting to the C locale. Ruby then reports an external
+		// encoding of US-ASCII, so commands read files and stdin as bytes and
+		// tag ENV strings ASCII-8BIT — interpolating a path with an accent in
+		// it into a UTF-8 string raises Encoding::CompatibilityError.
+		//
+		// bash_init.sh has always exported this, but fix_shebang only prepends
+		// that preamble to commands with no shebang of their own, so every
+		// "#!/usr/bin/env ruby" command went without. Setting it here covers
+		// them all. emplace leaves alone anything the user let through via the
+		// environmentWhitelist preference.
+		res.emplace("LC_CTYPE", "UTF-8");
+
 		res.emplace("TM_APP_IDENTIFIER", cf::to_s(CFBundleGetIdentifier(CFBundleGetMainBundle())));
 		res.emplace("TM_FULLNAME",       entry->pw_gecos ?: "John Doe");
 		res.emplace("TM_PID",            std::to_string(getpid()));

--- a/Frameworks/io/tests/t_environment.cc
+++ b/Frameworks/io/tests/t_environment.cc
@@ -1,0 +1,41 @@
+#include <io/environment.h>
+#include <io/exec.h>
+
+// A GUI app launched from Finder inherits no locale at all — the running
+// TextMate has only __CF_USER_TEXT_ENCODING, no LANG and no LC_*. Ruby then
+// reports Encoding.default_external as US-ASCII, so bundle commands read stdin
+// and files as bytes and tag ENV strings ASCII-8BIT. Interpolating a
+// TM_FILEPATH containing an accent into a UTF-8 literal raises
+// Encoding::CompatibilityError.
+//
+// bash_init.sh has always exported LC_CTYPE, but fix_shebang only prepends it
+// for commands with no shebang of their own, so every "#!/usr/bin/env ruby"
+// command missed out. Setting it here covers all of them.
+void test_environment_sets_lc_ctype ()
+{
+	auto const& env = oak::basic_environment();
+	auto it = env.find("LC_CTYPE");
+	OAK_ASSERT(it != env.end());
+	OAK_ASSERT_EQ(it->second, "UTF-8");
+}
+
+// Guard the rest of setup_basic_environment() against collateral damage.
+void test_environment_keeps_basic_keys ()
+{
+	auto const& env = oak::basic_environment();
+	for(char const* key : { "HOME", "PATH", "TMPDIR", "LOGNAME", "USER" })
+		OAK_ASSERT(env.find(key) != env.end());
+}
+
+// The map is only half of it — prove a spawned child actually receives the
+// variable, and that Ruby, which is what most bundle commands are written in,
+// resolves it to UTF-8 rather than falling back to US-ASCII.
+//
+// The equivalent end-to-end test belongs in the command suite, but that one is
+// excluded from CI: wait_for_command() polls NSApp, which is nil in a CLI test
+// binary, so it hangs. io::exec goes through the same oak::basic_environment().
+void test_environment_reaches_spawned_process ()
+{
+	OAK_ASSERT_EQ(io::exec("/bin/sh", "-c", "printf %s \"$LC_CTYPE\"", nullptr), "UTF-8");
+	OAK_ASSERT_EQ(io::exec("/usr/bin/ruby", "-e", "print Encoding.default_external", nullptr), "UTF-8");
+}


### PR DESCRIPTION
Launched from Finder the app inherits no locale at all. Checked against the running process:

```
$ ps eww -p $(pgrep -x TextMate) | tr " " "\n" | grep -E "^(LANG|LC_)"
__CF_USER_TEXT_ENCODING=0x1F5:0x0:0x52      # and nothing else
```

Neither `LANG` nor any `LC_*` is in the environment whitelist either, so everything we spawn runs in the C locale.

For Ruby — which is what most bundle commands are — that means `Encoding.default_external` is `US-ASCII`. Commands read files and stdin as bytes, and `ENV` strings come back tagged `ASCII-8BIT`, so interpolating a `TM_FILEPATH` containing an accent into a UTF-8 string raises `Encoding::CompatibilityError`:

```
locale unset : ENV=ASCII-8BIT len=5 | "café #{ENV[...]}" -> Encoding::CompatibilityError
UTF-8 locale : ENV=UTF-8      len=4 | "café #{ENV[...]}" -> 9
```

`bash_init.sh:2` has exported `LC_CTYPE` since forever, but `fix_shebang` only prepends that preamble to commands with **no shebang of their own** — so every `#!/usr/bin/env ruby` command has been going without. Setting it in `setup_basic_environment()` fixes all of them, and everything else we spawn, from the one place they all funnel through.

`emplace` rather than assignment, so a value the user lets through via the `environmentWhitelist` preference still wins.

### Tests

Three, in the **io** suite. The natural home is the command suite, but that is excluded from CI — `wait_for_command()` polls `NSApp`, which is nil in a CLI test binary, and the suite hangs (I confirmed this by writing the test there first). `io::exec` goes through the same `oak::basic_environment()`, so spawning `/usr/bin/ruby` proves the variable arrives where it actually matters:

```cpp
OAK_ASSERT_EQ(io::exec("/bin/sh", "-c", "printf %s \"$LC_CTYPE\"", nullptr), "UTF-8");
OAK_ASSERT_EQ(io::exec("/usr/bin/ruby", "-e", "print Encoding.default_external", nullptr), "UTF-8");
```

Written before the change and confirmed failing, then passing. `io_tests` goes 24 → 27.

One unrelated failure, `t_attributes.cc:26`, reproduces identically on clean `main` on this machine and passes in CI — an extra xattr locally, not touched by this.

Refs textmatelives/textmate#45