### PR TITLE
Fix KeyCue-triggered menu accessibility crash on macOS 26.6.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@ Title: Release Notes
 
 # Changes
 
+## Unreleased
+
+### Stability
+
+* **KeyCue and other accessibility clients no longer crash TextMate while inspecting menus on macOS 26.6.2.** AppKit's `NSMenu` accessibility path raises and internally catches a compatibility exception for its removed `accessibilityPerformAction:` fallback. TextMate's fail-fast exception observer previously called `abort()` before AppKit could catch it.
+
 ## 2026-08-26 (v2.2.0-undead)
 
 The rave build system is replaced by CMake, two crashes are fixed, and a fork-wide sweep gets bundle Ruby running on the system interpreter — 50 bundle pull requests across 40 repositories. See [all changes since v2.1.5-undead](https://github.com/textmatelives/textmate/compare/v2.1.5-undead...v2.2.0-undead).
@@ -2171,5 +2177,3 @@ Notable changes since to TextMate 1.5.10:
 * **Foreign Input Modes**
 
 	Display of CJK and “advanced” input modes is now be supported (although only limited testing has been done).
-
-

--- a/Frameworks/OakDebug/src/OakAssert.mm
+++ b/Frameworks/OakDebug/src/OakAssert.mm
@@ -6,6 +6,21 @@
 @interface OakExceptionHandlerDelegate : NSObject { }
 @end
 
+static BOOL IsAppKitMenuAccessibilityCompatibilityException (NSException* exception)
+{
+	/*
+	 * On macOS 26.6.2, -[NSMenu accessibilityPerformShowMenu] still dispatches
+	 * through the deprecated accessibilityPerformAction: API. AppKit's NSMenu
+	 * implementation forwards that selector to NSObject, which no longer
+	 * implements it, and the accessibility entry point catches the resulting
+	 * exception. NSExceptionHandler observes the exception before AppKit catches
+	 * it, though, so treating every observed exception as fatal makes menu
+	 * inspection by accessibility clients such as KeyCue abort TextMate.
+	 */
+	return [exception.name isEqualToString:NSInvalidArgumentException] &&
+	       [exception.reason hasPrefix:@"-[NSMenu accessibilityPerformAction:]: unrecognized selector sent to instance "];
+}
+
 std::string OakStackDump (int linesToSkip)
 {
 	void* callstack[256];
@@ -118,7 +133,7 @@ void OakPrintBadAssertion (char const* lhs, char const* op, char const* rhs, std
 
 - (BOOL)exceptionHandler:(NSExceptionHandler*)sender shouldLogException:(NSException*)exception mask:(NSUInteger)mask
 {
-	if([[exception name] isEqualToString:@"FSExecutionErrorException"])
+	if([exception.name isEqualToString:@"FSExecutionErrorException"] || IsAppKitMenuAccessibilityCompatibilityException(exception))
 		return NO;
 	os_log_error(OS_LOG_DEFAULT, "%{public}@: %{public}@\n", exception.name, exception.reason);
 	abort();


### PR DESCRIPTION
## Summary

- Prevent KeyCue and other accessibility clients from aborting TextMate while inspecting menus on macOS 26.6.2.
- Preserve the existing fail-fast behavior for every other Objective-C exception.
- Document the fix in the unreleased stability notes.

## Root cause

AppKit still routes NSMenu accessibilityPerformShowMenu through the deprecated accessibilityPerformAction: API. On macOS 26.6.2 that path raises NSInvalidArgumentException because the fallback selector is no longer implemented by NSObject. The accessibility entry point catches this framework compatibility exception, but TextMate’s NSExceptionHandler delegate observes it first and calls abort().

The crash is therefore reported as SIGABRT in OakExceptionHandlerDelegate, with the originating accessibility request attributed to KeyCue.

## Fix

Recognize only the exact NSInvalidArgumentException reason emitted by this NSMenu path and return without calling abort(), allowing AppKit to reach its own catch boundary. No NSMenu swizzling or broad NSInvalidArgumentException suppression is introduced.

## Verification

- Reproduced the exception with a minimal native NSMenu probe on macOS 26.6.2.
- Linked a regression harness against the rebuilt libOakDebug.a; it exits 0 after the exception reaches the outer catch boundary. Before this change the same path aborts.
- Built the complete Release TextMate target successfully with CMake and Ninja.
- Verified the resulting TextMate.app code signature with codesign --verify --deep --strict.
- git diff --check passes.

## Crash signature

    NSInvalidArgumentException: -[NSMenu accessibilityPerformAction:]: unrecognized selector sent to instance ...
    -[OakExceptionHandlerDelegate exceptionHandler:shouldLogException:mask:]
    -[NSMenu(Accessibility) accessibilityPerformAction:]
    -[NSMenu accessibilityPerformShowMenu]
