### PR TITLE
Release v2.2.1-undead

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,13 @@ Title: Release Notes
 
 # Changes
 
-## Unreleased
+## 2026-08-27 (v2.2.1-undead)
+
+One stability fix. See [all changes since v2.2.0-undead](https://github.com/textmatelives/textmate/compare/v2.2.0-undead...v2.2.1-undead).
 
 ### Stability
 
-* **KeyCue and other accessibility clients no longer crash TextMate while inspecting menus on macOS 26.6.2.** AppKit's `NSMenu` accessibility path raises and internally catches a compatibility exception for its removed `accessibilityPerformAction:` fallback. TextMate's fail-fast exception observer previously called `abort()` before AppKit could catch it.
+* **KeyCue and other accessibility clients no longer crash TextMate while inspecting menus on macOS 26.6.2.** AppKit's `NSMenu` accessibility path raises and internally catches a compatibility exception for its removed `accessibilityPerformAction:` fallback. TextMate's fail-fast exception observer previously called `abort()` before AppKit could catch it. Reported, diagnosed and fixed by [@BenjaminX](https://github.com/BenjaminX). ([#54](https://github.com/textmatelives/textmate/issues/54), [#55](https://github.com/textmatelives/textmate/pull/55), `172a78fa`)
 
 ## 2026-08-26 (v2.2.0-undead)
 


### PR DESCRIPTION
## Summary

Cuts patch release **v2.2.1-undead**. Merging this to main triggers `release.yml` on the CHANGELOG.md push: it reads the top version heading, builds, signs, notarizes and publishes the release.

The only change is retitling the `## Unreleased` CHANGELOG section (added by #55) to `## 2026-08-27 (v2.2.1-undead)`, adding the compare link and attribution. The app version is derived from this heading at configure time, so no other file changes are needed — same process as the v2.2.0-undead release commit.

## Contents of the release

One stability fix: the `NSExceptionHandler` delegate no longer aborts on the `NSMenu` accessibility compatibility exception that AppKit raises and internally catches on macOS 26.6.2. Previously, KeyCue or any other accessibility client inspecting TextMate's menus crashed the app deterministically. Reported, diagnosed and fixed by @BenjaminX (#54, #55).

## Verification

- `grep -om1 '^## .* (v.*)$' CHANGELOG.md` (the workflow's version step) yields `2.2.1-undead`.
- `bin/extract_changes -v 2.2.1-undead CHANGELOG.md` (the workflow's release-notes step) extracts exactly the new section.
- No `v2.2.1-undead` tag exists, so the workflow's tag guard passes.

Note: the `release` job runs in the gated `release` environment, so it will wait for reviewer approval in the Actions UI before touching the signing secrets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0199YBpmG8RWPPJEaXdyHk8s

---
_Generated by [Claude Code](https://claude.ai/code/session_0199YBpmG8RWPPJEaXdyHk8s)_