### PR TITLE
Software Update: add an experimental channel, retire the nightly one

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -296,12 +296,14 @@ jobs:
           VERSION: ${{ steps.version.outputs.version }}
         run: |
           set -euo pipefail
-          # -beta versions publish as GitHub prereleases: excluded from
-          # releases/latest (the stable update feed), picked up by the beta
-          # channel's list endpoint.
+          # Prerelease markers publish as GitHub prereleases, which keeps them
+          # out of releases/latest. -beta feeds the beta channel; -exp feeds the
+          # experimental channel. Which channel actually offers a tag is decided
+          # in OakVersionAdmissibleOnChannel, not here — this flag only governs
+          # how the release is presented on GitHub.
           PRERELEASE_FLAG=""
           case "${VERSION}" in
-            *-beta*) PRERELEASE_FLAG="--prerelease" ;;
+            *-beta*|*-exp*) PRERELEASE_FLAG="--prerelease" ;;
           esac
           gh release create "v${VERSION}" \
             ${PRERELEASE_FLAG} \

--- a/Applications/TextMate/src/AppController.mm
+++ b/Applications/TextMate/src/AppController.mm
@@ -100,7 +100,6 @@ BOOL HasDocumentWindow (NSArray* windows)
 				{ /* -------- */ },
 				{ @"Preferences…",          @selector(showPreferences:),            @","   },
 				{ @"Check for Update",      @selector(performSoftwareUpdateCheck:)         },
-				{ @"Check for Test Build",  @selector(performSoftwareUpdateCheck:),       .modifierFlags = NSEventModifierFlagCommand|NSEventModifierFlagOption, .alternate = YES },
 				{ /* -------- */ },
 				{ @"Services",              .systemMenu = MBMenuTypeServices               },
 				{ /* -------- */ },
@@ -490,15 +489,18 @@ BOOL HasDocumentWindow (NSArray* windows)
 	// textmatelives/textmate — what `git ls-remote` reads. Unlike the GitHub
 	// Releases API it is unmetered, so checks cannot be starved by the
 	// 60-requests/hour-per-IP quota (issue #26). SoftwareUpdate picks the
-	// highest refs/tags/v* version — the beta channel includes -beta tags,
-	// the others skip them, so beta users converge back onto stable when it
-	// catches up — and derives the download URL from release.yml's asset
-	// convention. No nightly stream exists, so Canary behaves like Release.
+	// highest refs/tags/v* version its channel admits and derives the
+	// download URL from release.yml's asset convention.
+	//
+	// All channels read the one feed: the streams are separated by the tag
+	// marker release.yml stamps (none / -beta / -exp), not by URL, so an
+	// experiment costs a tag convention rather than a second repository.
+	// OakVersionAdmissibleOnChannel owns which channel sees what.
 	NSURL* const feedURL = [NSURL URLWithString:@"https://github.com/textmatelives/textmate.git/info/refs?service=git-upload-pack"];
 	SoftwareUpdate.sharedInstance.channels = @{
-		kSoftwareUpdateChannelRelease:    feedURL,
-		kSoftwareUpdateChannelPrerelease: feedURL,
-		kSoftwareUpdateChannelCanary:     feedURL,
+		kSoftwareUpdateChannelRelease:      feedURL,
+		kSoftwareUpdateChannelPrerelease:   feedURL,
+		kSoftwareUpdateChannelExperimental: feedURL,
 	};
 
 	settings_t::set_default_settings_path([[[NSBundle mainBundle] pathForResource:@"Default" ofType:@"tmProperties"] fileSystemRepresentation]);

--- a/Frameworks/Preferences/src/SoftwareUpdatePreferences.mm
+++ b/Frameworks/Preferences/src/SoftwareUpdatePreferences.mm
@@ -24,7 +24,7 @@
 		icon = [NSImage imageWithSystemSymbolName:@"arrow.triangle.2.circlepath" accessibilityDescription:@"Software Update"];
 	if(self = [super initWithNibName:nil label:@"Software Update" image:icon])
 	{
-		[OakStringListTransformer createTransformerWithName:@"OakSoftwareUpdateChannelTransformer" andObjectsArray:@[ kSoftwareUpdateChannelRelease, kSoftwareUpdateChannelPrerelease ]];
+		[OakStringListTransformer createTransformerWithName:@"OakSoftwareUpdateChannelTransformer" andObjectsArray:@[ kSoftwareUpdateChannelRelease, kSoftwareUpdateChannelPrerelease, kSoftwareUpdateChannelExperimental ]];
 	}
 	return self;
 }
@@ -126,9 +126,11 @@
 	NSTextField* lastCheckTextField        = OakCreateLabel(@"Some time ago");
 	NSButton* checkNowButton               = [NSButton buttonWithTitle:@"Check Now" target:self.softwareUpdateController action:@selector(checkForUpdate:)];
 
+	// Tags are indices into OakSoftwareUpdateChannelTransformer's array above.
 	MBMenu const updateChannelMenuItems = {
-		{ @"Normal releases", .tag = 0 },
-		{ @"Prereleases",     .tag = 1 },
+		{ @"Normal releases",     .tag = 0 },
+		{ @"Prereleases",         .tag = 1 },
+		{ @"Experimental builds", .tag = 2 },
 	};
 	MBCreateMenu(updateChannelMenuItems, updateChannelPopUp.menu);
 

--- a/Frameworks/SoftwareUpdate/src/SoftwareUpdate.h
+++ b/Frameworks/SoftwareUpdate/src/SoftwareUpdate.h
@@ -5,7 +5,7 @@ extern NSString* const kUserDefaultsLastSoftwareUpdateCheckKey;
 
 extern NSString* const kSoftwareUpdateChannelRelease;
 extern NSString* const kSoftwareUpdateChannelPrerelease;
-extern NSString* const kSoftwareUpdateChannelCanary;
+extern NSString* const kSoftwareUpdateChannelExperimental;
 
 @interface SoftwareUpdate : NSObject
 @property (class, readonly) SoftwareUpdate* sharedInstance;
@@ -31,11 +31,25 @@ NSComparisonResult OakCompareVersionStrings (NSString* lhsString, NSString* rhsS
 NSString* OakSHAForRefInUploadPackAdvertisement (NSData* data, NSString* ref);
 
 // Returns the highest version (per OakCompareVersionStrings) among the
-// advertisement’s refs/tags/v<digit>… tags, stripped of the leading “v”.
-// Versions containing “-beta” are skipped unless includePrereleases — the
-// same convention release.yml uses to mark a release as a prerelease.
-// Returns nil if no tag qualifies or the data is malformed.
-NSString* OakLatestVersionInUploadPackAdvertisement (NSData* data, BOOL includePrereleases);
+// advertisement’s refs/tags/v<digit>… tags that `channel` is allowed to see,
+// stripped of the leading “v”. Returns nil if no tag qualifies or the data is
+// malformed.
+//
+// Channels are distinguished by the markers release.yml stamps onto a tag:
+//
+//   release        stable tags only (no marker).
+//   beta           stable + “-beta”, so a beta user converges back onto
+//                  stable once it catches up — beta content ships as stable
+//                  eventually.
+//   experimental   “-exp” only, deliberately WITHOUT that convergence: an
+//                  experimental stream may never merge, so offering a newer
+//                  stable would silently take away the feature the user opted
+//                  in to test.
+//
+// An unrecognised (or nil) channel is treated as release — the least
+// permissive reading, so a stale or hand-edited default cannot widen what a
+// user is offered.
+NSString* OakLatestVersionInUploadPackAdvertisement (NSData* data, NSString* channel);
 
 // Builds the release-asset URL for a version by convention — release.yml
 // uploads TextMate-{version}.tbz onto release v{version} — from the

--- a/Frameworks/SoftwareUpdate/src/SoftwareUpdate.mm
+++ b/Frameworks/SoftwareUpdate/src/SoftwareUpdate.mm
@@ -16,7 +16,12 @@ NSString* const kUserDefaultsSoftwareUpdateDisableReadOnlyFileSystemWarningKey =
 
 NSString* const kSoftwareUpdateChannelRelease                                  = @"release";
 NSString* const kSoftwareUpdateChannelPrerelease                               = @"beta";
-NSString* const kSoftwareUpdateChannelCanary                                   = @"nightly";
+NSString* const kSoftwareUpdateChannelExperimental                             = @"experimental";
+
+// Markers release.yml stamps onto a prerelease tag. A tag carrying neither is
+// a stable release.
+static NSString* const kVersionMarkerBeta         = @"-beta";
+static NSString* const kVersionMarkerExperimental = @"-exp";
 
 static BOOL is_hex (char ch)
 {
@@ -107,7 +112,34 @@ NSString* OakSHAForRefInUploadPackAdvertisement (NSData* data, NSString* ref)
 	return nil;
 }
 
-NSString* OakLatestVersionInUploadPackAdvertisement (NSData* data, BOOL includePrereleases)
+// Whether `version` is one that `channel` may be offered. See the contract in
+// SoftwareUpdate.h — in particular that beta converges onto stable and
+// experimental deliberately does not, and that an unknown channel falls back
+// to the least permissive answer rather than the most.
+static BOOL OakVersionAdmissibleOnChannel (NSString* version, NSString* channel)
+{
+	BOOL isBeta         = [version containsString:kVersionMarkerBeta];
+	BOOL isExperimental = [version containsString:kVersionMarkerExperimental];
+
+	if([channel isEqualToString:kSoftwareUpdateChannelExperimental])
+		return isExperimental;
+	else if([channel isEqualToString:kSoftwareUpdateChannelPrerelease])
+		return !isExperimental;
+	return !isBeta && !isExperimental;
+}
+
+// How a channel is named in messages shown to the user. Matches the wording
+// of the Preferences → Software Update pop-up.
+static NSString* OakDisplayNameForChannel (NSString* channel)
+{
+	if([channel isEqualToString:kSoftwareUpdateChannelExperimental])
+		return @"experimental";
+	else if([channel isEqualToString:kSoftwareUpdateChannelPrerelease])
+		return @"prerelease";
+	return @"release";
+}
+
+NSString* OakLatestVersionInUploadPackAdvertisement (NSData* data, NSString* channel)
 {
 	NSString* best = nil;
 	for(NSString* name in OakRefsInUploadPackAdvertisement(data))
@@ -121,7 +153,7 @@ NSString* OakLatestVersionInUploadPackAdvertisement (NSData* data, BOOL includeP
 
 		if(!tag.length || !isdigit([tag characterAtIndex:0])) // v2.1.0 yes, vendor-drop no
 			continue;
-		if(!includePrereleases && [tag containsString:@"-beta"]) // release.yml’s prerelease marker
+		if(!OakVersionAdmissibleOnChannel(tag, channel))
 			continue;
 
 		if(!best || OakCompareVersionStrings(best, tag) == NSOrderedAscending)
@@ -322,7 +354,7 @@ static BOOL OakBundleIsSignedByTeam (NSURL* appURL, NSString* expectedTeamID)
 				[NSUserDefaults.standardUserDefaults removeObjectForKey:kUserDefaultsSoftwareUpdateSuspendUntilKey];
 			}
 
-			[self checkForTestBuild:NO completionHandler:^(NSURL* remoteURL, NSString* remoteVersion, NSError* error){
+			[self checkWithCompletionHandler:^(NSURL* remoteURL, NSString* remoteVersion, NSError* error){
 				self.errorString = error ? [NSString stringWithFormat:@"Error: %@", error.localizedDescription] : nil;
 				if(error)
 				{
@@ -343,10 +375,9 @@ static BOOL OakBundleIsSignedByTeam (NSURL* appURL, NSString* expectedTeamID)
 
 - (void)checkForUpdate:(id)sender
 {
-	BOOL isOptionDown = OakIsAlternateKeyOrMouseEvent(NSEventModifierFlagOption);
-	BOOL isShiftDown  = OakIsAlternateKeyOrMouseEvent(NSEventModifierFlagShift);
+	BOOL isShiftDown = OakIsAlternateKeyOrMouseEvent(NSEventModifierFlagShift);
 
-	[self checkForTestBuild:isOptionDown completionHandler:^(NSURL* remoteURL, NSString* remoteVersion, NSError* error){
+	[self checkWithCompletionHandler:^(NSURL* remoteURL, NSString* remoteVersion, NSError* error){
 		SUDownloadViewController* alertViewController = [[SUDownloadViewController alloc] init];
 		if(error)
 				[alertViewController presentError:error];
@@ -354,9 +385,12 @@ static BOOL OakBundleIsSignedByTeam (NSURL* appURL, NSString* expectedTeamID)
 	}];
 }
 
-- (void)checkForTestBuild:(BOOL)testBuild completionHandler:(void(^)(NSURL* remoteURL, NSString* remoteVersion, NSError* error))completionHandler
+- (void)checkWithCompletionHandler:(void(^)(NSURL* remoteURL, NSString* remoteVersion, NSError* error))completionHandler
 {
-	NSString* updateChannel = testBuild ? kSoftwareUpdateChannelCanary : [NSUserDefaults.standardUserDefaults stringForKey:kUserDefaultsSoftwareUpdateChannelKey];
+	// The channel is whatever Preferences → Software Update is set to; there
+	// is no modifier-key override, so what a user is offered always matches
+	// what the pop-up says.
+	NSString* updateChannel = [NSUserDefaults.standardUserDefaults stringForKey:kUserDefaultsSoftwareUpdateChannelKey];
 	if(!updateChannel)
 		return completionHandler(nil, nil, [NSError errorWithDomain:@"SoftwareUpdate" code:0 userInfo:@{ NSLocalizedDescriptionKey: @"No channel configured." }]);
 
@@ -390,11 +424,26 @@ static BOOL OakBundleIsSignedByTeam (NSURL* appURL, NSString* expectedTeamID)
 				}
 				else if([contentType hasPrefix:@"application/x-git-upload-pack-advertisement"])
 				{
-					BOOL includePrereleases = [updateChannel isEqualToString:kSoftwareUpdateChannelPrerelease];
-					remoteVersion = OakLatestVersionInUploadPackAdvertisement(data, includePrereleases);
+					remoteVersion = OakLatestVersionInUploadPackAdvertisement(data, updateChannel);
 					remoteURL     = OakUpdateAssetURLForVersion(remoteVersion, url);
 					if(!remoteURL || !remoteVersion)
-						error = [NSError errorWithDomain:@"SoftwareUpdate" code:0 userInfo:@{ NSLocalizedDescriptionKey: @"No release tags in server response." }];
+					{
+						// Tell an empty channel apart from an unreadable feed. A
+						// channel with nothing published is an ordinary state —
+						// experimental streams exist only while an experiment is
+						// running — so saying the server sent no tags would be
+						// both wrong and alarming. The probe re-reads the same
+						// response against the release channel: if that finds a
+						// version, the feed was fine and the channel is simply
+						// empty. (The stringWithFormat: is parenthesised because
+						// its comma would otherwise read as an argument separator
+						// to the enclosing os_activity_initiate macro — brackets
+						// do not group for the preprocessor, parentheses do.)
+						NSString* message = OakLatestVersionInUploadPackAdvertisement(data, kSoftwareUpdateChannelRelease)
+							? ([NSString stringWithFormat:@"No %@ builds have been published yet.", OakDisplayNameForChannel(updateChannel)])
+							: @"No release tags in server response.";
+						error = [NSError errorWithDomain:@"SoftwareUpdate" code:0 userInfo:@{ NSLocalizedDescriptionKey: message }];
+					}
 				}
 				else
 				{

--- a/Frameworks/SoftwareUpdate/tests/t_upload_pack_advertisement.mm
+++ b/Frameworks/SoftwareUpdate/tests/t_upload_pack_advertisement.mm
@@ -102,8 +102,11 @@ void test_unresolvable_inputs ()
 // ====================================================
 
 // Tag layout mirroring the real textmatelives/textmate repo plus synthetic
-// betas; deliberately listed out of version order, since the advertisement
-// is sorted by ref name, not version.
+// betas and experimental builds; deliberately listed out of version order,
+// since the advertisement is sorted by ref name, not version. The
+// experimental tags sit at 2.3.0 — above every stable and beta tag here —
+// because that is the case that leaks: nothing about being newer may make
+// an experiment visible to a channel that did not ask for it.
 static NSData* version_tags ()
 {
 	return advertisement(@[
@@ -116,20 +119,40 @@ static NSData* version_tags ()
 		str([NSString stringWithFormat:@"%@ refs/tags/v2.1.2-undead\n", kTagObjectSHA]),
 		str([NSString stringWithFormat:@"%@ refs/tags/v2.1.2-undead^{}\n", kPeeledSHA]),
 		str([NSString stringWithFormat:@"%@ refs/tags/v2.1.1-undead\n", kTagObjectSHA]),
+		str([NSString stringWithFormat:@"%@ refs/tags/v2.3.0-undead-exp.2\n", kTagObjectSHA]),
+		str([NSString stringWithFormat:@"%@ refs/tags/v2.3.0-undead-exp.10\n", kTagObjectSHA]),
 	]);
 }
 
-void test_latest_version_release_channel_excludes_betas ()
+void test_latest_version_release_channel_excludes_prereleases ()
 {
-	// 2.1.10-undead-beta.* outrank 2.1.2-undead per OakCompareVersionStrings,
-	// but the release channel must not see them.
-	OAK_ASSERT([OakLatestVersionInUploadPackAdvertisement(version_tags(), NO) isEqualToString:@"2.1.2-undead"]);
+	// Both 2.1.10-undead-beta.* and 2.3.0-undead-exp.* outrank 2.1.2-undead
+	// per OakCompareVersionStrings; the release channel must see neither.
+	OAK_ASSERT([OakLatestVersionInUploadPackAdvertisement(version_tags(), kSoftwareUpdateChannelRelease) isEqualToString:@"2.1.2-undead"]);
 }
 
-void test_latest_version_beta_channel_includes_betas ()
+void test_latest_version_beta_channel_includes_betas_not_experiments ()
 {
-	// Max overall — and numerically: beta.10 > beta.2.
-	OAK_ASSERT([OakLatestVersionInUploadPackAdvertisement(version_tags(), YES) isEqualToString:@"2.1.10-undead-beta.10"]);
+	// Max among stable+beta — and numerically: beta.10 > beta.2. The newer
+	// experimental tags stay invisible, or opting into betas would drag the
+	// user onto an experiment they never asked for.
+	OAK_ASSERT([OakLatestVersionInUploadPackAdvertisement(version_tags(), kSoftwareUpdateChannelPrerelease) isEqualToString:@"2.1.10-undead-beta.10"]);
+}
+
+void test_latest_version_experimental_channel_sees_only_experiments ()
+{
+	// Deliberately no convergence onto stable: an experimental stream may
+	// never merge, so offering the newest stable would silently take away
+	// the feature the user opted in to test. Also numeric: exp.10 > exp.2.
+	OAK_ASSERT([OakLatestVersionInUploadPackAdvertisement(version_tags(), kSoftwareUpdateChannelExperimental) isEqualToString:@"2.3.0-undead-exp.10"]);
+}
+
+void test_latest_version_unknown_channel_is_treated_as_stable ()
+{
+	// A channel string from a future build (or a hand-edited default) must
+	// not fall through to something more permissive than release.
+	OAK_ASSERT([OakLatestVersionInUploadPackAdvertisement(version_tags(), @"no-such-channel") isEqualToString:@"2.1.2-undead"]);
+	OAK_ASSERT([OakLatestVersionInUploadPackAdvertisement(version_tags(), nil) isEqualToString:@"2.1.2-undead"]);
 }
 
 void test_latest_version_ignores_non_version_refs ()
@@ -141,23 +164,27 @@ void test_latest_version_ignores_non_version_refs ()
 		str([NSString stringWithFormat:@"%@ refs/tags/3.0.0\n", kTagObjectSHA]),
 		str([NSString stringWithFormat:@"%@ refs/tags/v2.1.1-undead\n", kTagObjectSHA]),
 	]);
-	OAK_ASSERT([OakLatestVersionInUploadPackAdvertisement(data, YES) isEqualToString:@"2.1.1-undead"]);
+	OAK_ASSERT([OakLatestVersionInUploadPackAdvertisement(data, kSoftwareUpdateChannelPrerelease) isEqualToString:@"2.1.1-undead"]);
 
 	// Only beta tags exist → the release channel finds nothing.
 	NSData* betasOnly = advertisement(@[
 		str([NSString stringWithFormat:@"%@ refs/tags/v2.1.2-undead-beta.1\n", kTagObjectSHA]),
 	]);
-	OAK_ASSERT(OakLatestVersionInUploadPackAdvertisement(betasOnly, NO) == nil);
-	OAK_ASSERT([OakLatestVersionInUploadPackAdvertisement(betasOnly, YES) isEqualToString:@"2.1.2-undead-beta.1"]);
+	OAK_ASSERT(OakLatestVersionInUploadPackAdvertisement(betasOnly, kSoftwareUpdateChannelRelease) == nil);
+	OAK_ASSERT([OakLatestVersionInUploadPackAdvertisement(betasOnly, kSoftwareUpdateChannelPrerelease) isEqualToString:@"2.1.2-undead-beta.1"]);
+
+	// No experimental tags → the experimental channel finds nothing rather
+	// than falling back to stable.
+	OAK_ASSERT(OakLatestVersionInUploadPackAdvertisement(betasOnly, kSoftwareUpdateChannelExperimental) == nil);
 }
 
 void test_latest_version_malformed_or_empty ()
 {
-	OAK_ASSERT(OakLatestVersionInUploadPackAdvertisement(nil, YES) == nil);
-	OAK_ASSERT(OakLatestVersionInUploadPackAdvertisement(str(@"HTTP/1.1 403 Forbidden"), YES) == nil);
-	OAK_ASSERT(OakLatestVersionInUploadPackAdvertisement(advertisement(@[ ]), YES) == nil);
+	OAK_ASSERT(OakLatestVersionInUploadPackAdvertisement(nil, kSoftwareUpdateChannelPrerelease) == nil);
+	OAK_ASSERT(OakLatestVersionInUploadPackAdvertisement(str(@"HTTP/1.1 403 Forbidden"), kSoftwareUpdateChannelPrerelease) == nil);
+	OAK_ASSERT(OakLatestVersionInUploadPackAdvertisement(advertisement(@[ ]), kSoftwareUpdateChannelPrerelease) == nil);
 	// sample() carries tags “1.0.0” (no v prefix — skipped) and “v2” (qualifies).
-	OAK_ASSERT([OakLatestVersionInUploadPackAdvertisement(sample(), NO) isEqualToString:@"2"]);
+	OAK_ASSERT([OakLatestVersionInUploadPackAdvertisement(sample(), kSoftwareUpdateChannelRelease) isEqualToString:@"2"]);
 }
 
 // ====================================


### PR DESCRIPTION
## Summary

Adds an **experimental** software-update channel so a feature stream can ship to willing testers without going near the mainline, and retires the inert **nightly** (Canary) channel.

Canary pointed at the same feed as Release and the tag filter only widened for Prerelease, so it saw exactly what Release saw. Its sole entry point — the Option-key **Check for Test Build** alternate menu item — was a duplicate of **Check for Update**. Both are removed.

All three channels still read the one `textmatelives/textmate` feed. The streams are separated by the tag marker `release.yml` stamps, not by URL, so an experiment costs a tag convention rather than a second repository:

| channel | admits | converges to stable |
|---|---|---|
| `release` | stable only | — |
| `beta` | stable + `-beta` | yes |
| `experimental` | `-exp` only | **no** |

The missing convergence is deliberate. An experimental stream may never merge, so offering a newer stable would silently take away the feature the user opted in to test. Betas do eventually ship as stable, so converging there stays correct.

### Why the old filter had to change

`OakLatestVersionInUploadPackAdvertisement` took `BOOL includePrereleases` and filtered on the substring `-beta` alone. Any other suffix passed that test, so a `v2.3.0-undead-exp.1` tag would have outranked `v2.2.1-undead` under `OakCompareVersionStrings` and been offered to **stable** users. It is now channel-aware, and an unrecognised or `nil` channel resolves to `release` — the least permissive reading — so a stale or hand-edited default cannot widen what a user is offered.

### Other changes

- The channel is read only from Preferences, with no modifier-key override, so what a user is offered always matches what the pop-up says.
- `release.yml` marks `-exp` as a GitHub prerelease alongside `-beta`, keeping it out of `releases/latest`.
- An empty channel is distinguished from an unreadable feed. A stream with nothing published is an ordinary state; reporting *"No release tags in server response"* for it was both wrong and alarming. It now reads *"No experimental builds have been published yet."*

### Cutting an experimental release

No new workflow is needed. `release.yml` already has `workflow_dispatch`, its `actions/checkout` pins no `ref:`, and it tags with `--target "${GITHUB_SHA}"` — so dispatching it from a feature branch runs the build+test gate, signs, notarizes, staples and publishes against that branch's commit.

## Test plan

- [x] `SoftwareUpdate` tests pass (22/22), including four new cases covering release/beta/experimental admission and the unknown-channel fallback
- [x] Tests demonstrably catch the leak: restoring the old filter semantics fails 3 of them, showing both the release **and** beta channels being dragged onto `v2.3.0-undead-exp.10`
- [x] Full `TextMate` target builds clean
- [x] Verified against the live feed — Experimental correctly reports no builds published (zero `-exp` tags exist), Prereleases correctly reports Up To Date (zero `-beta` tags exist, so it converges onto `2.2.1-undead`)
- [ ] Cut a real `-exp` build via `workflow_dispatch` and confirm it is offered on Experimental and invisible on Release/Prereleases

## Notes

- `CHANGELOG.md` is deliberately untouched, so merging this does **not** trigger a release.
- Any install whose `SoftwareUpdateChannel` default was hand-set to `nightly` will now error with *"No channel named 'nightly'."* It was never selectable through the UI. A one-line `nightly`→`release` migration in `+initialize` can be added if that is worth guarding.
