### PR TITLE
Offer the changelog once after an update, instead of opening it

### DIFF
--- a/Applications/TextMate/src/AboutWindowController.h
+++ b/Applications/TextMate/src/AboutWindowController.h
@@ -1,6 +1,6 @@
 @interface AboutWindowController : NSWindowController
 @property (class, readonly) AboutWindowController* sharedInstance;
-+ (void)showChangesIfUpdated;
++ (void)showUpdateNoticeIfNeeded;
 - (void)showAboutWindow:(id)sender;
 - (void)showChangesWindow:(id)sender;
 @end

--- a/Applications/TextMate/src/AboutWindowController.mm
+++ b/Applications/TextMate/src/AboutWindowController.mm
@@ -4,15 +4,7 @@
 #import <OakFoundation/NSString Additions.h>
 #import <ns/ns.h>
 
-static NSString* const kUserDefaultsReleaseNotesDigestKey = @"releaseNotesDigest";
-
-static NSData* Digest (NSString* someString)
-{
-	char const* str = [someString UTF8String];
-	char md[CC_SHA1_DIGEST_LENGTH];
-	CC_SHA1((unsigned char*)str, strlen(str), (unsigned char*)md);
-	return [NSData dataWithBytes:md length:sizeof(md)];
-}
+static NSString* const kUserDefaultsLastLaunchedVersionKey = @"lastLaunchedVersion";
 
 @interface AboutWindowController () <NSWindowDelegate, NSToolbarDelegate, WKNavigationDelegate, WKScriptMessageHandler>
 @property (nonatomic, readonly) NSArray<NSString*>* segmentLabels;
@@ -29,20 +21,43 @@ static NSData* Digest (NSString* someString)
 	return sharedInstance;
 }
 
-+ (void)showChangesIfUpdated
++ (void)showUpdateNoticeIfNeeded
 {
-	NSURL* url = [[NSBundle mainBundle] URLForResource:@"CHANGELOG" withExtension:@"html"];
-	dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_LOW, 0), ^{
-		if(NSString* releaseNotes = [NSString stringWithContentsOfURL:url encoding:NSUTF8StringEncoding error:NULL])
-		{
-			NSData* lastDigest    = [NSUserDefaults.standardUserDefaults dataForKey:kUserDefaultsReleaseNotesDigestKey];
-			NSData* currentDigest = Digest(releaseNotes);
-			dispatch_async(dispatch_get_main_queue(), ^{
-				if(lastDigest && ![lastDigest isEqualToData:currentDigest])
-					[AboutWindowController.sharedInstance showChangesWindow:self];
-				[NSUserDefaults.standardUserDefaults setObject:currentDigest forKey:kUserDefaultsReleaseNotesDigestKey];
-			});
-		}
+	// Offers the changelog once, the first time a newly installed version is
+	// run. It does not open the release notes by itself: an app that throws its
+	// own changelog at you on launch is a nuisance, so the window only appears
+	// if the notice is answered with Changelog.
+	//
+	// The trigger is the running version, not the content of the release notes.
+	// A digest of CHANGELOG.html would also fire when the notes changed without
+	// the version doing so, which is not what "you have been updated" means.
+	NSUserDefaults* defaults = NSUserDefaults.standardUserDefaults;
+
+	NSString* currentVersion = [NSBundle.mainBundle objectForInfoDictionaryKey:@"CFBundleShortVersionString"];
+	if(!currentVersion.length)
+		return;
+
+	NSString* lastVersion = [defaults stringForKey:kUserDefaultsLastLaunchedVersionKey];
+	[defaults setObject:currentVersion forKey:kUserDefaultsLastLaunchedVersionKey];
+
+	// Nothing to announce on a first run — no version was left behind to have
+	// come from — nor when relaunching the version already recorded. Any change
+	// counts, in either direction: the update dialog offers downgrades too, so
+	// the wording states the version rather than claiming an upgrade.
+	if(!lastVersion.length || [lastVersion isEqualToString:currentVersion])
+		return;
+
+	// Deferred so the alert is not run modally from inside the launch sequence.
+	dispatch_async(dispatch_get_main_queue(), ^{
+		NSAlert* alert        = [[NSAlert alloc] init];
+		alert.messageText     = @"TextMate Has Been Updated";
+		alert.informativeText = [NSString stringWithFormat:@"You are now running version %@.", currentVersion];
+
+		[alert addButtonWithTitle:@"Changelog"]; // first added is the default
+		[alert addButtonWithTitle:@"Cancel"];
+
+		if([alert runModal] == NSAlertFirstButtonReturn)
+			[AboutWindowController.sharedInstance showChangesWindow:self];
 	});
 }
 
@@ -133,10 +148,6 @@ static NSData* Digest (NSString* someString)
 {
 	self.selectedPage = @"Changes";
 	[self showWindow:self];
-
-	NSURL* url = [[NSBundle mainBundle] URLForResource:@"CHANGELOG" withExtension:@"html"];
-	if(NSString* releaseNotes = [NSString stringWithContentsOfURL:url encoding:NSUTF8StringEncoding error:NULL])
-		[NSUserDefaults.standardUserDefaults setObject:Digest(releaseNotes) forKey:kUserDefaultsReleaseNotesDigestKey];
 }
 
 - (void)takeSelectedSegmentFrom:(id)sender

--- a/Applications/TextMate/src/AppController.mm
+++ b/Applications/TextMate/src/AppController.mm
@@ -578,7 +578,7 @@ BOOL HasDocumentWindow (NSArray* windows)
 	[[selectMenu itemWithTitle:@"Toggle Column Selection"] setActivationString:@"⌥" withFont:nil];
 
 	[TerminalPreferences updateMateIfRequired];
-	[AboutWindowController showChangesIfUpdated];
+	[AboutWindowController showUpdateNoticeIfNeeded];
 
 	[OakCommitWindowServer sharedInstance]; // Setup server
 


### PR DESCRIPTION
## Summary

Closes the second half of #56 — *"or in a popup after the update is applied"*.

That popup **already existed and has been dead since 2021.** `AboutWindowController.showChangesIfUpdated` is called on every launch from `AppController.mm`, but it looked the release notes up with `URLForResource:@"CHANGELOG"` — no subdirectory — while the file ships at `Contents/Resources/About/CHANGELOG.html`. `NSBundle` does not search arbitrary subdirectories, so the URL was `nil`, the string was `nil`, and the body never executed: the window never opened **and** the digest was never stored. `showChangesWindow:` stored the digest through the same broken lookup, so nothing seeded it either.

Verified against the built bundle:

```
URLForResource:@"CHANGELOG"        -> (nil)
URLForResource:@"About/CHANGELOG"  -> …/Contents/Resources/About/CHANGELOG.html
```

`setSelectedPage:` uses the qualified path, which is why the About window's Changes tab has always worked.

**Origin:** Allan's `5d87b8ef` (2021-05-26) moved the files into `About/` and updated the page map but left both bare lookups. It is present at the shared upstream baseline `346b52b1`, and `tectiv3/textmate` still carries it. This tree only renamed `Changes` → `CHANGELOG`, faithfully carrying it forward.

## What it does now

Rather than restoring the old behaviour, the notice **does not open anything by itself** — an app that throws its own release notes at you on launch is a nuisance. It shows a small alert naming the version, with **Changelog** as the default button and **Cancel** beside it. The Changes tab opens only if you ask for it.

The trigger is the running `CFBundleShortVersionString` against a stored `lastLaunchedVersion`, not a digest of the notes — a digest also fires when the notes change without the version doing so, which is not what "you have been updated" means. That retires the digest, its SHA-1 helper, and both dead lookups.

Any version change counts, in either direction: the update dialog offers downgrades too, so the wording states the version rather than claiming an upgrade.

## Test plan

- [x] Built clean
- [x] Seeded `lastLaunchedVersion=2.0.0-test`, relaunched — alert appeared, and the default flipped to `2.2.1-undead`, proving the path ran
- [x] Changelog button opens the About window on the Changes tab (confirmed by hand)
- [ ] Confirm in the beta that it stays quiet on the upgrade that *delivers* it, and fires on the next one

## Note

By design this cannot fire on the update that ships it — no `lastLaunchedVersion` exists yet, so that launch records the version and stays silent, the same guard that keeps fresh installs quiet. Seeing it work end-to-end needs two hops (beta.1 → beta.2, or beta → stable).