### PR TITLE
Drop the dev bundle identifier that was never wired up

### DIFF
--- a/Applications/TextMate/CMakeLists.txt
+++ b/Applications/TextMate/CMakeLists.txt
@@ -14,15 +14,23 @@ target_link_libraries(TextMate PRIVATE
 
 target_link_libraries(TextMate PRIVATE "-framework Cocoa" "-framework UniformTypeIdentifiers")
 
-# Info.plist variable expansion
+# Info.plist variable expansion. Info.plist names the app through
+# ${TARGET_NAME} — CFBundleName is ${TARGET_NAME}, CFBundleIdentifier is
+# com.macromates.${TARGET_NAME} — so that is the only variable the expansion
+# reads.
+#
+# A BUNDLE_IDENTIFIER/BUNDLE_NAME pair giving non-Release builds a
+# "com.macromates.TextMate-dev" identity came across with the CMake migration
+# but was never referenced here, so it has never had any effect: every build,
+# local or CI, has identified as com.macromates.TextMate. It is not restored,
+# deliberately. Applications/mate looks the app up by a hardcoded
+# com.macromates.TextMate (mate.mm), so a separate development identity would
+# quietly point `mate` at whatever stable build is installed instead of the one
+# being debugged, and would ask for its own TCC grants. Both cost more than the
+# preference isolation they would buy. Nothing shipped is affected either way:
+# CI configures Release (release.yml, build-and-test.yml), and Application
+# Support is pinned to "TextMate" in main.mm regardless of CFBundleName.
 set(TARGET_NAME "TextMate")
-if(CMAKE_BUILD_TYPE STREQUAL "Release")
-  set(BUNDLE_IDENTIFIER "com.macromates.TextMate")
-  set(BUNDLE_NAME "TextMate")
-else()
-  set(BUNDLE_IDENTIFIER "com.macromates.TextMate-dev")
-  set(BUNDLE_NAME "TextMate-dev")
-endif()
 set(APP_MIN_OS "${CMAKE_OSX_DEPLOYMENT_TARGET}")
 set(APP_VERSION "${TEXTMATE_VERSION}")
 string(TIMESTAMP YEAR "%Y")


### PR DESCRIPTION
## Summary

`Applications/TextMate/CMakeLists.txt` set `BUNDLE_IDENTIFIER`/`BUNDLE_NAME` to give non-Release builds a `com.macromates.TextMate-dev` identity. **Neither variable was ever referenced.** This tree's `Info.plist` still names the app through `${TARGET_NAME}` — `CFBundleName` is `${TARGET_NAME}`, `CFBundleIdentifier` is `com.macromates.${TARGET_NAME}` — the form inherited from rave, with `TARGET_NAME` hardcoded to `TextMate`.

So the conditional has never had any effect: every build here, local or CI, identifies as `com.macromates.TextMate`. Confirmed with a clean Debug configure in a scratch directory, so it is not a stale-cache artifact, and `grep` finds no other reference to either variable.

**It's a porting gap.** `tectiv3/textmate`'s `CMakeLists.txt` block is identical to ours — we took it verbatim — but *their* `Info.plist` uses `${BUNDLE_IDENTIFIER}` and `${BUNDLE_NAME}`. That half didn't come across.

## Why removed rather than completed

- `Applications/mate` looks the app up by a **hardcoded** `com.macromates.TextMate` (`mate.mm`). A separate development identity would silently point `mate` at whatever stable build is installed rather than the one being debugged — a confusing thing to hand a contributor mid-debug.
- A second identity asks for its own TCC grants.
- Both cost more than the preference isolation they'd buy.

A comment records this reasoning in place, so the block isn't reinstated without the `mate` caveat.

## Blast radius: none

- CI configures `-DCMAKE_BUILD_TYPE=Release` in both `release.yml` and `build-and-test.yml`, so every shipped artifact was already on the stable identity and is unaffected.
- Application Support is pinned to `TextMate` in `main.mm` regardless of `CFBundleName`, so no settings or bundle tree moves.
- Only locally-built non-Release binaries were ever in scope, and for those nothing changes either — they were already `com.macromates.TextMate`.

## Test plan

- [x] Clean Debug configure still yields `com.macromates.TextMate`
- [x] `TextMate` target builds