### PR TITLE
Show the SCM status shortcut in its tool tip

### DIFF
--- a/Frameworks/FileBrowser/src/OFB/OFBActionsView.mm
+++ b/Frameworks/FileBrowser/src/OFB/OFBActionsView.mm
@@ -34,13 +34,18 @@ static NSButton* OakCreateImageButton (NSImage* image)
 		self.reloadButton.toolTip       = @"Reload file browser";
 		self.searchButton.toolTip       = @"Search current folder";
 		self.favoritesButton.toolTip    = @"Show favorites";
-		self.scmButton.toolTip          = @"Show source control management status";
+		// A button cannot display a key equivalent, so the tool tip carries it —
+		// the binding is otherwise only discoverable under the File Browser menu,
+		// which is not where one looks for an SCM action. Kept in step with
+		// AppController's "SCM Status" item, which owns the shortcut.
+		NSString* const scmDescription  = @"Show source control management status";
+		self.scmButton.toolTip          = [scmDescription stringByAppendingString:@" (⇧⌘Y)"];
 
 		self.reloadButton.image.accessibilityDescription    = self.reloadButton.toolTip;
 		self.createButton.image.accessibilityDescription    = self.createButton.toolTip;
 		self.searchButton.image.accessibilityDescription    = self.searchButton.toolTip;
 		self.favoritesButton.image.accessibilityDescription = self.favoritesButton.toolTip;
-		self.scmButton.image.accessibilityDescription       = self.scmButton.toolTip;
+		self.scmButton.image.accessibilityDescription       = scmDescription;
 
 		NSView* wrappedActionsPopUpButton = [NSView new];
 		OakAddAutoLayoutViewsToSuperview(@[ self.actionsPopUpButton ], wrappedActionsPopUpButton);


### PR DESCRIPTION
## Summary

The file browser's SCM button already has a keyboard shortcut — **⇧⌘Y**, via the *SCM Status* item in the **File Browser** menu (`AppController.mm`) — but nothing surfaces it. A button cannot display a key equivalent, and the menu it lives under isn't where you'd look for an SCM action, so the binding is effectively invisible.

The tool tip now reads:

> Show source control management status (⇧⌘Y)

The accessibility description keeps the plain wording, since VoiceOver announces key equivalents on its own.

## Notes

- No behaviour change — the shortcut already worked. I confirmed nothing else in the tree claims `@"Y"`, and that `goToSCMDataSource:` is **not** in `validateMenuItem:`'s `delegateToFileBrowser` set, so it stays enabled with the file browser closed (the action sets `fileBrowserVisible = YES` itself).
- The shortcut is spelled out in the view rather than derived from the menu, with a comment pointing at the item that owns it, so the two stay in step.

## Test plan

- [x] Builds clean
- [ ] Hover the SCM button and confirm the tool tip reads the shortcut