### PR TITLE
RELEASING: correct step 12 for prerelease versions

### DIFF
--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -95,8 +95,13 @@ fresh in this job):
    Gatekeeper** with `spctl --assess` (`:242-262`).
 10. **Build the `.tbz`** `TextMate-${VERSION}.tbz` (`:264-275`).
 11. **Extract release notes** with `bin/extract_changes` (`:277-289`).
-12. **Create the GitHub Release** with `gh release create "v${VERSION}"` — no
-    `--prerelease`/`--draft`, so it becomes `releases/latest` (`:291-302`).
+12. **Create the GitHub Release** with `gh release create "v${VERSION}"`
+    (`:292-314`). A stable version gets neither `--prerelease` nor `--draft`, so
+    it becomes `releases/latest`. A `-beta` or `-exp` version is published with
+    `--prerelease` (`:304-307`), which keeps it out of `releases/latest`. That
+    flag only governs how GitHub presents the release; which update channel is
+    actually offered a tag is decided by `OakVersionAdmissibleOnChannel` in
+    `Frameworks/SoftwareUpdate`.
 13. **Delete the ephemeral keychain** (always) (`:304-306`).
 
 ## Required GitHub secrets


### PR DESCRIPTION
## Summary

`docs/RELEASING.md` step 12 claimed the GitHub release is created with *"no `--prerelease`/`--draft`, so it becomes `releases/latest`"*. That hasn't been unconditionally true since the beta channel shipped — `release.yml` marks `-beta` versions as prereleases — and #58 added `-exp` for the experimental channel.

Corrected to describe both paths, and to note that the flag governs only how GitHub *presents* the release: which update channel is actually offered a tag is decided by `OakVersionAdmissibleOnChannel` in `Frameworks/SoftwareUpdate`, not by this flag.

Line references refreshed too — they shifted when #58 landed.

Docs only; no code change.

## Test plan

- [x] Line references checked against the current `release.yml`