### PR TITLE
Show release notes in the update dialog

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -289,6 +289,23 @@ jobs:
           echo "::endgroup::"
           echo "notes_file=$NOTES_FILE" >> "$GITHUB_OUTPUT"
 
+      # The in-app update dialog shows these notes before the download. It
+      # fetches TextMate-${VERSION}-notes.html from this release by convention
+      # (OakUpdateReleaseNotesURLForVersion, Frameworks/SoftwareUpdate) and
+      # renders it with scripts off. Same converter as the About window’s
+      # Changes page, without the page template: the app supplies its own.
+      - name: Render release notes for the update dialog
+        if: steps.tagcheck.outputs.should_release == 'true'
+        id: notes_html
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          set -euo pipefail
+          HTML_FILE="$RUNNER_TEMP/TextMate-${VERSION}-notes.html"
+          bin/gen_html -t "TextMate ${VERSION}" "${{ steps.notes.outputs.notes_file }}" > "$HTML_FILE"
+          test -s "$HTML_FILE"
+          echo "notes_html=$HTML_FILE" >> "$GITHUB_OUTPUT"
+
       - name: Create GitHub release
         if: steps.tagcheck.outputs.should_release == 'true'
         env:
@@ -311,7 +328,8 @@ jobs:
             --title "TextMate ${VERSION}" \
             --notes-file "${{ steps.notes.outputs.notes_file }}" \
             --generate-notes \
-            "${{ steps.archive.outputs.archive }}"
+            "${{ steps.archive.outputs.archive }}" \
+            "${{ steps.notes_html.outputs.notes_html }}"
 
       - name: Cleanup keychain
         if: always()

--- a/Frameworks/SoftwareUpdate/src/SoftwareUpdate.h
+++ b/Frameworks/SoftwareUpdate/src/SoftwareUpdate.h
@@ -57,6 +57,20 @@ NSString* OakLatestVersionInUploadPackAdvertisement (NSData* data, NSString* cha
 // when either input doesn’t fit.
 NSURL* OakUpdateAssetURLForVersion (NSString* version, NSURL* advertisementURL);
 
+// Builds the release-notes URL for a version by the same convention —
+// release.yml renders the version’s CHANGELOG.md section with bin/gen_html to
+// TextMate-{version}-notes.html and uploads it next to the .tbz. Returns nil
+// when either input doesn’t fit.
+NSURL* OakUpdateReleaseNotesURLForVersion (NSString* version, NSURL* advertisementURL);
+
+// Wraps a release-notes fragment (bin/gen_html output) in the document the
+// update dialog renders: the given stylesheet inline, and a
+// Content-Security-Policy that permits nothing beyond that stylesheet and
+// data: images — no scripts, network, frames or fonts — since the fragment
+// arrives over the network without the signature check the .tbz gets.
+// Returns nil when the fragment is empty.
+NSString* OakUpdateReleaseNotesDocument (NSString* fragment, NSString* stylesheet);
+
 // Maps a non-2xx HTTP response to an NSError, preferring the “message” field
 // GitHub puts in error bodies (e.g. “API rate limit exceeded for …”) over a
 // bare status code. Returns nil for 2xx or non-HTTP responses.

--- a/Frameworks/SoftwareUpdate/src/SoftwareUpdate.mm
+++ b/Frameworks/SoftwareUpdate/src/SoftwareUpdate.mm
@@ -6,6 +6,7 @@
 #import <OakAppKit/OakTransitionViewController.h>
 #import <OakAppKit/OakUIConstructionFunctions.h>
 #import <Security/Security.h>
+#import <WebKit/WebKit.h>
 
 NSString* const kUserDefaultsLastSoftwareUpdateCheckKey                        = @"SoftwareUpdateLastPoll";
 NSString* const kUserDefaultsSoftwareUpdateSuspendUntilKey                     = @"SoftwareUpdateSuspendUntil";
@@ -162,7 +163,9 @@ NSString* OakLatestVersionInUploadPackAdvertisement (NSData* data, NSString* cha
 	return best;
 }
 
-NSURL* OakUpdateAssetURLForVersion (NSString* version, NSURL* advertisementURL)
+// {host}/{owner}/{repo}/releases/download/v{version}/{fileName}, derived from
+// the advertisement URL’s /{owner}/{repo}.git/info/refs shape.
+static NSURL* OakReleaseAssetURL (NSString* version, NSURL* advertisementURL, NSString* fileName)
 {
 	if(!version.length)
 		return nil;
@@ -173,7 +176,55 @@ NSURL* OakUpdateAssetURLForVersion (NSString* version, NSURL* advertisementURL)
 		return nil;
 
 	NSString* repo = [parts[2] substringToIndex:[parts[2] length] - 4];
-	return [NSURL URLWithString:[NSString stringWithFormat:@"https://%@/%@/%@/releases/download/v%@/TextMate-%@.tbz", advertisementURL.host, parts[1], repo, version, version]];
+	return [NSURL URLWithString:[NSString stringWithFormat:@"https://%@/%@/%@/releases/download/v%@/%@", advertisementURL.host, parts[1], repo, version, fileName]];
+}
+
+NSURL* OakUpdateAssetURLForVersion (NSString* version, NSURL* advertisementURL)
+{
+	return OakReleaseAssetURL(version, advertisementURL, [NSString stringWithFormat:@"TextMate-%@.tbz", version]);
+}
+
+NSURL* OakUpdateReleaseNotesURLForVersion (NSString* version, NSURL* advertisementURL)
+{
+	return OakReleaseAssetURL(version, advertisementURL, [NSString stringWithFormat:@"TextMate-%@-notes.html", version]);
+}
+
+// The notes pane is styled like the About window’s Changes page, whose
+// stylesheet (About/css/stylesheet.css) and background image ship in the
+// application bundle. The image is inlined as a data: URI so the document
+// needs no base URL and therefore no file access; the CSP permits data:
+// images and nothing else. Falls back to a plain stylesheet when the About
+// resources are missing, e.g. in the test runner.
+static NSString* OakReleaseNotesStylesheet ()
+{
+	NSURL* cssURL = [NSBundle.mainBundle URLForResource:@"stylesheet" withExtension:@"css" subdirectory:@"About/css"];
+	NSString* css = cssURL ? [NSString stringWithContentsOfURL:cssURL encoding:NSUTF8StringEncoding error:nullptr] : nil;
+	if(!css)
+		return @":root { color-scheme: light dark; }\nbody { font: 13px/1.6 -apple-system, sans-serif; color: CanvasText; margin: 1.15rem; }\na { color: LinkText; }\n";
+
+	NSURL* imageURL = [NSBundle.mainBundle URLForResource:@"tml_image" withExtension:@"png" subdirectory:@"About/css"];
+	if(NSData* image = imageURL ? [NSData dataWithContentsOfURL:imageURL] : nil)
+		css = [css stringByReplacingOccurrencesOfString:@"url(\"tml_image.png\")" withString:[NSString stringWithFormat:@"url(\"data:image/png;base64,%@\")", [image base64EncodedStringWithOptions:0]]];
+
+	// The About page sits in a 700 pt window; in a pane its margin is a bezel.
+	return [css stringByAppendingString:@"\nbody { margin: 0.6rem; }\n"];
+}
+
+NSString* OakUpdateReleaseNotesDocument (NSString* fragment, NSString* stylesheet)
+{
+	if(![fragment stringByTrimmingCharactersInSet:NSCharacterSet.whitespaceAndNewlineCharacterSet].length)
+		return nil;
+
+	return [NSString stringWithFormat:
+		@"<!DOCTYPE html>\n"
+		 "<html>\n"
+		 "<head>\n"
+		 "<meta charset=\"utf-8\">\n"
+		 "<meta http-equiv=\"Content-Security-Policy\" content=\"default-src 'none'; style-src 'unsafe-inline'; img-src data:\">\n"
+		 "<style>\n%@\n</style>\n"
+		 "</head>\n"
+		 "<body>\n%@\n</body>\n"
+		 "</html>\n", stylesheet ?: @"", fragment];
 }
 
 // Case-insensitive header lookup (HTTP/2 lowercases header names; the
@@ -282,7 +333,7 @@ static BOOL OakBundleIsSignedByTeam (NSURL* appURL, NSString* expectedTeamID)
 
 @interface SUDownloadViewController : NSViewController
 - (instancetype)initWithCompletionHandler:(void(^)())completionHandler;
-- (void)presentUIForBackgroundCheck:(BOOL)backgroundCheck remoteURL:(NSURL*)remoteURL remoteVersion:(NSString*)remoteVersion redownloadEnabled:(BOOL)allowRedownload;
+- (void)presentUIForBackgroundCheck:(BOOL)backgroundCheck remoteURL:(NSURL*)remoteURL remoteVersion:(NSString*)remoteVersion releaseNotes:(NSString*)releaseNotes redownloadEnabled:(BOOL)allowRedownload;
 @end
 
 // ==================
@@ -354,7 +405,7 @@ static BOOL OakBundleIsSignedByTeam (NSURL* appURL, NSString* expectedTeamID)
 				[NSUserDefaults.standardUserDefaults removeObjectForKey:kUserDefaultsSoftwareUpdateSuspendUntilKey];
 			}
 
-			[self checkWithCompletionHandler:^(NSURL* remoteURL, NSString* remoteVersion, NSError* error){
+			[self checkWithCompletionHandler:^(NSURL* remoteURL, NSString* remoteVersion, NSString* releaseNotes, NSError* error){
 				self.errorString = error ? [NSString stringWithFormat:@"Error: %@", error.localizedDescription] : nil;
 				if(error)
 				{
@@ -366,7 +417,7 @@ static BOOL OakBundleIsSignedByTeam (NSURL* appURL, NSString* expectedTeamID)
 					SUDownloadViewController* alertViewController = [[SUDownloadViewController alloc] initWithCompletionHandler:^{
 						completionHandler(NSBackgroundActivityResultFinished);
 					}];
-					[alertViewController presentUIForBackgroundCheck:YES remoteURL:remoteURL remoteVersion:remoteVersion redownloadEnabled:NO];
+					[alertViewController presentUIForBackgroundCheck:YES remoteURL:remoteURL remoteVersion:remoteVersion releaseNotes:releaseNotes redownloadEnabled:NO];
 				}
 			}];
 		}];
@@ -377,26 +428,26 @@ static BOOL OakBundleIsSignedByTeam (NSURL* appURL, NSString* expectedTeamID)
 {
 	BOOL isShiftDown = OakIsAlternateKeyOrMouseEvent(NSEventModifierFlagShift);
 
-	[self checkWithCompletionHandler:^(NSURL* remoteURL, NSString* remoteVersion, NSError* error){
+	[self checkWithCompletionHandler:^(NSURL* remoteURL, NSString* remoteVersion, NSString* releaseNotes, NSError* error){
 		SUDownloadViewController* alertViewController = [[SUDownloadViewController alloc] init];
 		if(error)
 				[alertViewController presentError:error];
-		else	[alertViewController presentUIForBackgroundCheck:NO remoteURL:remoteURL remoteVersion:remoteVersion redownloadEnabled:isShiftDown];
+		else	[alertViewController presentUIForBackgroundCheck:NO remoteURL:remoteURL remoteVersion:remoteVersion releaseNotes:releaseNotes redownloadEnabled:isShiftDown];
 	}];
 }
 
-- (void)checkWithCompletionHandler:(void(^)(NSURL* remoteURL, NSString* remoteVersion, NSError* error))completionHandler
+- (void)checkWithCompletionHandler:(void(^)(NSURL* remoteURL, NSString* remoteVersion, NSString* releaseNotes, NSError* error))completionHandler
 {
 	// The channel is whatever Preferences → Software Update is set to; there
 	// is no modifier-key override, so what a user is offered always matches
 	// what the pop-up says.
 	NSString* updateChannel = [NSUserDefaults.standardUserDefaults stringForKey:kUserDefaultsSoftwareUpdateChannelKey];
 	if(!updateChannel)
-		return completionHandler(nil, nil, [NSError errorWithDomain:@"SoftwareUpdate" code:0 userInfo:@{ NSLocalizedDescriptionKey: @"No channel configured." }]);
+		return completionHandler(nil, nil, nil, [NSError errorWithDomain:@"SoftwareUpdate" code:0 userInfo:@{ NSLocalizedDescriptionKey: @"No channel configured." }]);
 
 	NSURL* url = _channels[updateChannel];
 	if(!url)
-		return completionHandler(nil, nil, [NSError errorWithDomain:@"SoftwareUpdate" code:0 userInfo:@{ NSLocalizedDescriptionKey: [NSString stringWithFormat:@"No channel named ‘%@’.", updateChannel] }]);
+		return completionHandler(nil, nil, nil, [NSError errorWithDomain:@"SoftwareUpdate" code:0 userInfo:@{ NSLocalizedDescriptionKey: [NSString stringWithFormat:@"No channel named ‘%@’.", updateChannel] }]);
 
 	os_activity_initiate("Software update check", OS_ACTIVITY_FLAG_DEFAULT, ^{
 		self.checking = YES;
@@ -456,14 +507,47 @@ static BOOL OakBundleIsSignedByTeam (NSURL* appURL, NSString* expectedTeamID)
 				}
 			}
 
-			dispatch_async(dispatch_get_main_queue(), ^{
-				[NSUserDefaults.standardUserDefaults setObject:[NSDate date] forKey:kUserDefaultsLastSoftwareUpdateCheckKey];
-				self.checking = NO;
-				completionHandler(remoteURL, remoteVersion, error);
-			});
+			// Only an offered update shows the dialog the notes go in, so only
+			// then are they fetched. (Commas stay inside parentheses: this is
+			// still the body of the os_activity_initiate macro.)
+			NSString* localVersion = [NSBundle.mainBundle objectForInfoDictionaryKey:@"CFBundleShortVersionString"];
+			NSURL* notesURL = (!error && OakCompareVersionStrings(localVersion, remoteVersion) == NSOrderedAscending) ? OakUpdateReleaseNotesURLForVersion(remoteVersion, url) : nil;
+
+			[self fetchReleaseNotesAtURL:notesURL completionHandler:^(NSString* releaseNotes){
+				dispatch_async(dispatch_get_main_queue(), ^{
+					[NSUserDefaults.standardUserDefaults setObject:[NSDate date] forKey:kUserDefaultsLastSoftwareUpdateCheckKey];
+					self.checking = NO;
+					completionHandler(remoteURL, remoteVersion, releaseNotes, error);
+				});
+			}];
 		}];
 		[dataTask resume];
 	});
+}
+
+// Fetches the rendered release notes for an offered version. The notes are an
+// optional pane on the update dialog, so every failure — no asset on this
+// release (none published before this shipped carries one), a slow network,
+// a body that is not text — completes with nil and the dialog appears without
+// the pane, as it did before. The dialog waits for this before it is shown,
+// so that it appears complete rather than growing a pane after the fact; the
+// short timeout keeps a manual check responsive when the asset is slow.
+- (void)fetchReleaseNotesAtURL:(NSURL*)url completionHandler:(void(^)(NSString* fragment))completionHandler
+{
+	if(!url)
+		return completionHandler(nil);
+
+	NSMutableURLRequest* request = [NSMutableURLRequest requestWithURL:url cachePolicy:NSURLRequestUseProtocolCachePolicy timeoutInterval:10];
+	[request setValue:OakDownloadManager.sharedInstance.userAgentString forHTTPHeaderField:@"User-Agent"];
+
+	NSURLSessionDataTask* dataTask = [NSURLSession.sharedSession dataTaskWithRequest:request completionHandler:^(NSData* data, NSURLResponse* response, NSError* error){
+		NSInteger statusCode = [response isKindOfClass:NSHTTPURLResponse.class] ? ((NSHTTPURLResponse*)response).statusCode : 0;
+		NSString* fragment = (!error && statusCode == 200) ? [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding] : nil;
+		if(!fragment)
+			os_log(OS_LOG_DEFAULT, "No release notes at %{public}@: %{public}@", url.absoluteString, error ? error.localizedDescription : [NSString stringWithFormat:@"HTTP %ld", (long)statusCode]);
+		completionHandler(fragment);
+	}];
+	[dataTask resume];
 }
 @end
 
@@ -474,6 +558,11 @@ static BOOL OakBundleIsSignedByTeam (NSURL* appURL, NSString* expectedTeamID)
 @interface SUInfoViewController : NSViewController
 @property (nonatomic) NSTextField* messageTextField;
 @property (nonatomic) NSTextField* informativeTextField;
+// Set when the dialog is wider than the text column would make it — a
+// release-notes pane below — so the column takes the width it is given
+// instead of its own 298 pt. Optional priorities do not work here: any pull
+// toward a narrower width makes AppKit snap a resized window back to it.
+@property (nonatomic) BOOL fillsWidth;
 @end
 
 @interface SUProgressViewController : NSViewController
@@ -483,9 +572,12 @@ static BOOL OakBundleIsSignedByTeam (NSURL* appURL, NSString* expectedTeamID)
 @property (nonatomic) NSProgress*          progress;
 @end
 
-@interface SUDownloadViewController ()
+@interface SUDownloadViewController () <WKNavigationDelegate>
 {
 	SUDownloadViewController* _retainedSelf;
+
+	NSBox*     _releaseNotesBox;
+	WKWebView* _releaseNotesView;
 
 	void(^_completionHandler)();
 	BOOL(^_runModalCompletionHandler)(NSModalResponse);
@@ -529,6 +621,9 @@ static BOOL OakBundleIsSignedByTeam (NSURL* appURL, NSString* expectedTeamID)
 
 - (void)dealloc
 {
+	_releaseNotesView.navigationDelegate = nil;
+	[_releaseNotesView stopLoading];
+
 	if(_completionHandler)
 		_completionHandler();
 }
@@ -575,21 +670,83 @@ static BOOL OakBundleIsSignedByTeam (NSURL* appURL, NSString* expectedTeamID)
 	NSImage* image = [NSImage imageNamed:NSImageNameApplicationIcon];
 	image.size = NSMakeSize(64, 64);
 
-	NSDictionary* views = @{
+	NSMutableDictionary* views = [@{
 		@"image":   [NSImageView imageViewWithImage:image],
 		@"content": self.contentViewController.view,
 		@"buttons": self.buttonStackView,
-	};
+	} mutableCopy];
+	if(_releaseNotesBox)
+		views[@"notes"] = _releaseNotesBox;
 
 	NSView* contentView = [[NSView alloc] initWithFrame:NSZeroRect];
 	OakAddAutoLayoutViewsToSuperview(views.allValues, contentView);
 
-	[NSLayoutConstraint activateConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"H:|-(24)-[image(==64)]-(16)-[content]-|"          options:NSLayoutFormatAlignAllTop metrics:nil views:views]];
-	[NSLayoutConstraint activateConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"H:[image]-(>=20)-[buttons]-|"                     options:0                         metrics:nil views:views]];
-	[NSLayoutConstraint activateConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"V:|-(16)-[image(==64)]-(>=20)-|"                  options:0                         metrics:nil views:views]];
-	[NSLayoutConstraint activateConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"V:[content]-(==20@750,>=20@250)-[buttons]-(18)-|" options:0                         metrics:nil views:views]];
+	[NSLayoutConstraint activateConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"H:|-(24)-[image(==64)]-(16)-[content]-|" options:NSLayoutFormatAlignAllTop metrics:nil views:views]];
+	[NSLayoutConstraint activateConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"H:[image]-(>=20)-[buttons]-|"            options:0                         metrics:nil views:views]];
+	[NSLayoutConstraint activateConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"V:|-(16)-[image(==64)]-(>=20)-|"         options:0                         metrics:nil views:views]];
+
+	if(_releaseNotesBox)
+	{
+		// The pane runs the full width under the icon and the text column,
+		// hugging whichever of the two ends lower, and takes all the height the
+		// window has to give (its vertical hugging priority is the lowest in
+		// the dialog).
+		[NSLayoutConstraint activateConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"H:|-(24)-[notes]-|"                           options:0 metrics:nil views:views]];
+		[NSLayoutConstraint activateConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"V:[image]-(==12@750,>=12)-[notes]"             options:0 metrics:nil views:views]];
+		[NSLayoutConstraint activateConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"V:[content]-(>=12)-[notes]-(20)-[buttons]-(18)-|" options:0 metrics:nil views:views]];
+	}
+	else
+	{
+		[NSLayoutConstraint activateConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"V:[content]-(==20@750,>=20@250)-[buttons]-(18)-|" options:0 metrics:nil views:views]];
+	}
 
 	self.view = contentView;
+}
+
+// Adds a pane with the offered version’s release notes, laid out by
+// -loadView, so this must run before the view loads. Scripts are off, and the
+// document’s Content-Security-Policy admits no subresources beyond data:
+// images (OakUpdateReleaseNotesDocument), so the pane renders text, links and
+// the About page’s backdrop, and nothing else. The size is a minimum: the
+// panel becomes resizable once the pane exists (-runModalWithCompletionHandler:).
+- (void)showReleaseNotesDocument:(NSString*)html
+{
+	NSAssert(!self.viewLoaded, @"release notes must be added before the view loads");
+
+	if(!_releaseNotesBox)
+	{
+		self.infoViewController.fillsWidth = YES;
+
+		WKWebViewConfiguration* configuration = [[WKWebViewConfiguration alloc] init];
+		configuration.defaultWebpagePreferences.allowsContentJavaScript = NO;
+
+		_releaseNotesView = [[WKWebView alloc] initWithFrame:NSZeroRect configuration:configuration];
+		_releaseNotesView.navigationDelegate = self;
+
+		_releaseNotesBox = [[NSBox alloc] initWithFrame:NSZeroRect];
+		_releaseNotesBox.boxType            = NSBoxCustom;
+		_releaseNotesBox.borderColor        = NSColor.separatorColor;
+		_releaseNotesBox.cornerRadius       = 5;
+		_releaseNotesBox.contentViewMargins = NSZeroSize;
+		_releaseNotesBox.contentView        = _releaseNotesView;
+		[_releaseNotesBox setContentHuggingPriority:1 forOrientation:NSLayoutConstraintOrientationVertical];
+		[_releaseNotesBox.widthAnchor  constraintGreaterThanOrEqualToConstant:560].active = YES;
+		[_releaseNotesBox.heightAnchor constraintGreaterThanOrEqualToConstant:360].active = YES;
+	}
+	[_releaseNotesView loadHTMLString:html baseURL:nil];
+}
+
+// The only navigation the pane starts itself is the loadHTMLString: above,
+// which loads as about:blank. Anything else is a link in the notes: it goes
+// to the browser, and the pane stays on the notes.
+- (void)webView:(WKWebView*)webView decidePolicyForNavigationAction:(WKNavigationAction*)navigationAction decisionHandler:(void(^)(WKNavigationActionPolicy))decisionHandler
+{
+	if(navigationAction.navigationType == WKNavigationTypeOther && [navigationAction.request.URL.absoluteString isEqualToString:@"about:blank"])
+		return decisionHandler(WKNavigationActionPolicyAllow);
+
+	if(navigationAction.request.URL)
+		[NSWorkspace.sharedWorkspace openURL:navigationAction.request.URL];
+	decisionHandler(WKNavigationActionPolicyCancel);
 }
 
 - (void)viewWillAppear
@@ -652,6 +809,20 @@ static BOOL OakBundleIsSignedByTeam (NSURL* appURL, NSString* expectedTeamID)
 	window.level                   = NSModalPanelWindowLevel;
 	window.styleMask               = NSWindowStyleMaskTitled;
 
+	// With release notes on board the panel may be resized to read them; the
+	// pane takes the extra space (SUInfoViewController) and the fitting size
+	// is the floor.
+	if(_releaseNotesBox)
+	{
+		window.styleMask      |= NSWindowStyleMaskResizable;
+		window.contentMinSize  = self.view.fittingSize;
+
+		// A resizable titled window grows the three title-bar buttons, two of
+		// them disabled; this is still an alert, so keep the title bar bare.
+		for(NSWindowButton button : { NSWindowCloseButton, NSWindowMiniaturizeButton, NSWindowZoomButton })
+			[window standardWindowButton:button].hidden = YES;
+	}
+
 	// If we use -[NSApplication runModalForWindow:] then the window
 	// won’t stay above document windows after the modal session ends
 	_runModalCompletionHandler = completionHandler;
@@ -689,7 +860,7 @@ static BOOL OakBundleIsSignedByTeam (NSURL* appURL, NSString* expectedTeamID)
 	}
 }
 
-- (void)presentUIForBackgroundCheck:(BOOL)backgroundCheck remoteURL:(NSURL*)remoteURL remoteVersion:(NSString*)remoteVersion redownloadEnabled:(BOOL)allowRedownload
+- (void)presentUIForBackgroundCheck:(BOOL)backgroundCheck remoteURL:(NSURL*)remoteURL remoteVersion:(NSString*)remoteVersion releaseNotes:(NSString*)releaseNotes redownloadEnabled:(BOOL)allowRedownload
 {
 	NSString* localVersion = [NSBundle.mainBundle objectForInfoDictionaryKey:@"CFBundleShortVersionString"];
 	NSComparisonResult ordering = OakCompareVersionStrings(localVersion, remoteVersion);
@@ -703,6 +874,9 @@ static BOOL OakBundleIsSignedByTeam (NSURL* appURL, NSString* expectedTeamID)
 	{
 		self.infoViewController.messageTextField.stringValue     = @"New Version Available";
 		self.infoViewController.informativeTextField.stringValue = [NSString stringWithFormat: @"%@ %@ is now available. You have version %@. Would you like to download it now?", [NSBundle.mainBundle objectForInfoDictionaryKey:@"CFBundleName"], remoteVersion, localVersion];
+
+		if(NSString* document = OakUpdateReleaseNotesDocument(releaseNotes, OakReleaseNotesStylesheet()))
+			[self showReleaseNotesDocument:document];
 
 		[self addButtonWithTitle:@"Download"];
 		[self addButtonWithTitle:backgroundCheck ? @"Later" : @"Cancel"];
@@ -900,7 +1074,19 @@ static BOOL OakBundleIsSignedByTeam (NSURL* appURL, NSString* expectedTeamID)
 // = SUInfoViewController =
 // ========================
 
+@interface SUInfoViewController ()
+{
+	NSLayoutConstraint* _widthConstraint;
+}
+@end
+
 @implementation SUInfoViewController
+- (void)setFillsWidth:(BOOL)flag
+{
+	_fillsWidth = flag;
+	_widthConstraint.active = !flag;
+}
+
 - (void)loadView
 {
 	_messageTextField     = [NSTextField labelWithString:@"New Version Available"];
@@ -919,7 +1105,8 @@ static BOOL OakBundleIsSignedByTeam (NSURL* appURL, NSString* expectedTeamID)
 	_informativeTextField.selectable = YES;
 	_informativeTextField.font       = [NSFont messageFontOfSize:NSFont.smallSystemFontSize];
 
-	[stackView.widthAnchor constraintEqualToConstant:298].active = YES;
+	_widthConstraint = [stackView.widthAnchor constraintEqualToConstant:298];
+	_widthConstraint.active = !_fillsWidth;
 
 	self.view = stackView;
 }

--- a/Frameworks/SoftwareUpdate/tests/t_upload_pack_advertisement.mm
+++ b/Frameworks/SoftwareUpdate/tests/t_upload_pack_advertisement.mm
@@ -209,3 +209,60 @@ void test_asset_url_rejects_malformed_inputs ()
 	OAK_ASSERT(OakUpdateAssetURLForVersion(@"2.1.2-undead", [NSURL URLWithString:@"https://github.com/textmatelives/textmate"]) == nil);
 	OAK_ASSERT(OakUpdateAssetURLForVersion(@"2.1.2-undead", [NSURL URLWithString:@"https://api.github.com/repos/textmatelives/textmate/releases/latest"]) == nil);
 }
+
+// ============================================
+// = OakUpdateReleaseNotesURLForVersion       =
+// ============================================
+
+void test_release_notes_url_from_advertisement_url ()
+{
+	// release.yml renders the version’s CHANGELOG section to
+	// TextMate-{version}-notes.html and uploads it next to the .tbz; the URL
+	// is derived from the advertisement URL by the same convention.
+	NSURL* feed = [NSURL URLWithString:@"https://github.com/textmatelives/textmate.git/info/refs?service=git-upload-pack"];
+	NSURL* expected = [NSURL URLWithString:@"https://github.com/textmatelives/textmate/releases/download/v2.1.2-undead/TextMate-2.1.2-undead-notes.html"];
+	OAK_ASSERT([OakUpdateReleaseNotesURLForVersion(@"2.1.2-undead", feed) isEqual:expected]);
+}
+
+void test_release_notes_url_rejects_malformed_inputs ()
+{
+	NSURL* feed = [NSURL URLWithString:@"https://github.com/textmatelives/textmate.git/info/refs?service=git-upload-pack"];
+	OAK_ASSERT(OakUpdateReleaseNotesURLForVersion(nil, feed) == nil);
+	OAK_ASSERT(OakUpdateReleaseNotesURLForVersion(@"", feed) == nil);
+	OAK_ASSERT(OakUpdateReleaseNotesURLForVersion(@"2.1.2-undead", nil) == nil);
+	OAK_ASSERT(OakUpdateReleaseNotesURLForVersion(@"2.1.2-undead", [NSURL URLWithString:@"https://github.com/textmatelives/textmate"]) == nil);
+	OAK_ASSERT(OakUpdateReleaseNotesURLForVersion(@"2.1.2-undead", [NSURL URLWithString:@"https://api.github.com/repos/textmatelives/textmate/releases/latest"]) == nil);
+}
+
+// ====================================
+// = OakUpdateReleaseNotesDocument    =
+// ====================================
+
+void test_release_notes_document_wraps_fragment ()
+{
+	NSString* fragment   = @"<article>\n<h2>2026-08-27 (v2.2.1-undead)</h2>\n<p>One fix.</p>\n</article>";
+	NSString* stylesheet = @"body { color: red; }";
+	NSString* html = OakUpdateReleaseNotesDocument(fragment, stylesheet);
+	OAK_ASSERT(html != nil);
+	OAK_ASSERT([html hasPrefix:@"<!DOCTYPE html>"]);
+	OAK_ASSERT([html containsString:fragment]);
+	OAK_ASSERT([html containsString:stylesheet]);
+	// The fragment is fetched over the network without the signature check
+	// the .tbz gets, so the document it renders in must permit nothing beyond
+	// its own inline stylesheet and data: images: no scripts, no network.
+	OAK_ASSERT([html containsString:@"http-equiv=\"Content-Security-Policy\""]);
+	OAK_ASSERT([html containsString:@"default-src 'none'"]);
+	OAK_ASSERT([html containsString:@"style-src 'unsafe-inline'"]);
+	OAK_ASSERT([html containsString:@"img-src data:"]);
+	// A missing stylesheet must not leak “(null)” into the page.
+	OAK_ASSERT(![OakUpdateReleaseNotesDocument(fragment, nil) containsString:@"(null)"]);
+}
+
+void test_release_notes_document_rejects_empty ()
+{
+	// An empty or whitespace-only asset means there is nothing to show; the
+	// dialog then omits the pane rather than rendering a blank box.
+	OAK_ASSERT(OakUpdateReleaseNotesDocument(nil, @"") == nil);
+	OAK_ASSERT(OakUpdateReleaseNotesDocument(@"", @"") == nil);
+	OAK_ASSERT(OakUpdateReleaseNotesDocument(@" \n\t", @"") == nil);
+}

--- a/bin/gen_html
+++ b/bin/gen_html
@@ -81,6 +81,9 @@ filters    = "|#{filter} --nosmart"
 
 document   = ARGF.read.force_encoding('UTF-8')
 document   = wrap_authors(wrap_key_equivalents(document))
+# multimarkdown reads `[#54](url)` as a citation, rendering “(1)(url)” plus a
+# footnote list instead of a link. Escaping the hash makes it an ordinary link.
+document   = document.gsub(/\[#(?=\d+\]\()/) { %q{[\#} }
 head, body = document.scan(/\A((?:^\w+:\s+.*$\n)*)\n?((?m:.*))\z/).flatten
 tmp        = head.scan(/^(\w+):\s+(.*)$/).collect { |pair| [pair[0].downcase, pair[1].strip] }
 headers    = Hash[*tmp.flatten]

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -49,7 +49,9 @@ The `-undead` suffix is **required** (see the guard below).
 4. Merge the PR to `main`. The push to `main` touching `CHANGELOG.md` triggers
    the `Release` workflow (`release.yml:4-7`).
 5. Watch the `Release` run. On success it produces the `vX.Y.Z-undead` tag and a
-   public GitHub Release with the `TextMate-X.Y.Z-undead.tbz` asset attached.
+   public GitHub Release with two assets attached: `TextMate-X.Y.Z-undead.tbz`
+   and `TextMate-X.Y.Z-undead-notes.html`, the release notes as the in-app
+   update dialog shows them.
 6. Confirm an installed older build is offered the update (see "How users get
    it" below).
 
@@ -94,15 +96,20 @@ fresh in this job):
 9. **Staple** the ticket (retried until CloudKit propagates) and **verify
    Gatekeeper** with `spctl --assess` (`:242-262`).
 10. **Build the `.tbz`** `TextMate-${VERSION}.tbz` (`:264-275`).
-11. **Extract release notes** with `bin/extract_changes` (`:277-289`).
-12. **Create the GitHub Release** with `gh release create "v${VERSION}"`
-    (`:292-314`). A stable version gets neither `--prerelease` nor `--draft`, so
+11. **Extract release notes** with `bin/extract_changes` (`:278-291`).
+12. **Render the release notes for the update dialog** with `bin/gen_html`
+    (`:297-308`): the same converter as the About window's Changes
+    page, without the page template. The app fetches this file from the
+    release by name and renders it in the "New Version Available" dialog before
+    the download (see "How users get the update").
+13. **Create the GitHub Release** with `gh release create "v${VERSION}"`
+    (`:309-333`), attaching both assets. A stable version gets neither `--prerelease` nor `--draft`, so
     it becomes `releases/latest`. A `-beta` or `-exp` version is published with
-    `--prerelease` (`:304-307`), which keeps it out of `releases/latest`. That
+    `--prerelease` (`:321-324`), which keeps it out of `releases/latest`. That
     flag only governs how GitHub presents the release; which update channel is
     actually offered a tag is decided by `OakVersionAdmissibleOnChannel` in
     `Frameworks/SoftwareUpdate`.
-13. **Delete the ephemeral keychain** (always) (`:304-306`).
+14. **Delete the ephemeral keychain** (always) (`:334-336`).
 
 ## Required GitHub secrets
 
@@ -119,14 +126,27 @@ identity is matched by name (`CERT_IDENTITY_NAME` = "Developer ID Application").
 
 ## How users get the update
 
-The app checks `api.github.com/repos/textmatelives/textmate/releases/latest`
-(`Applications/TextMate/src/AppController.mm:494`), compares the running
-`CFBundleShortVersionString` against the release `tag_name`, downloads the first
-`.tbz` asset, and installs it only if the downloaded bundle carries a valid
-Developer ID Application signature whose Team Identifier matches the **running**
-app (`Frameworks/SoftwareUpdate/src/SoftwareUpdate.mm`). It then swaps the bundle
-in place and relaunches. A build signed by a different team — or unsigned — is
-refused.
+The app reads the repository's git ref advertisement
+(`github.com/textmatelives/textmate.git/info/refs?service=git-upload-pack`,
+`Applications/TextMate/src/AppController.mm:499`) — what `git ls-remote` uses,
+and unmetered, unlike the Releases API (issue #26) — and picks the highest
+`refs/tags/v*` version its update channel admits. Both release assets are then
+addressed by convention rather than looked up
+(`Frameworks/SoftwareUpdate/src/SoftwareUpdate.h`):
+
+* `releases/download/v{version}/TextMate-{version}-notes.html` is fetched
+  first, when the version is newer than the running one, and shown in the
+  "New Version Available" dialog above the Download button. It renders in a
+  web view with JavaScript off, inside a document whose Content-Security-Policy
+  permits nothing but its own stylesheet, and every link opens in the browser.
+  If the fetch fails — every release before this asset existed answers 404 —
+  the dialog appears without the notes pane.
+* `releases/download/v{version}/TextMate-{version}.tbz` is downloaded on
+  Download, and installed only if the bundle carries a valid Developer ID
+  Application signature whose Team Identifier matches the **running** app
+  (`Frameworks/SoftwareUpdate/src/SoftwareUpdate.mm`). It then swaps the bundle
+  in place and relaunches. A build signed by a different team — or unsigned —
+  is refused.
 
 ## Gotchas
 


### PR DESCRIPTION
## Summary

Fixes #56. The "New Version Available" dialog now shows the offered version's release notes above the Download button, in a resizable pane styled like the About window's Changes page — what @damienmckenna described, OfficeTime-style, rather than the post-update notice from #59 (which stays).

**Where the notes come from.** The updater deliberately touches only unmetered endpoints (#26): the ref advertisement for the version, `releases/download/…` for the `.tbz`, the asset URL derived by convention. The Releases API that carries a release body is exactly what #26 removed, and `raw.githubusercontent.com` would be a new host plus a markdown renderer the app does not have (multimarkdown is build-time only). So `release.yml` renders the version's `CHANGELOG.md` section with the existing `bin/gen_html` to `TextMate-{version}-notes.html` and uploads it next to the `.tbz`; the app derives that URL the same way it derives the `.tbz` one (`OakUpdateReleaseNotesURLForVersion`) and fetches it only when a newer version is offered, 10 s timeout. Any failure — every release before this one answers 404 — leaves the dialog exactly as it is today.

**Rendering safety.** The notes arrive without the Developer ID gate the `.tbz` gets. They render in a `WKWebView` with JavaScript off, wrapped in a document whose `Content-Security-Policy` is `default-src 'none'; style-src 'unsafe-inline'; img-src data:` — the only image being the About backdrop, inlined from the bundle — and a navigation delegate that hands every link to the browser. A tampered asset can at worst look wrong.

**Layout.** The pane runs the full width under the icon and text, with the header row compact at the top; the panel is resizable only when a pane is present and the pane alone absorbs growth (minimum 604×514 content). The three title-bar buttons a resizable titled panel grows are hidden so it still reads as an alert.

**`bin/gen_html`.** multimarkdown reads `[#54](url)` as a citation and rendered `(1)(url)` plus a footnote list — 54 such artefacts across `CHANGELOG.md`, visible in the About window's Changes page all along. One escape before the pipe fixes both surfaces: 54 → 0, 58 `#NN` links now render as links.

## Testing

- `SoftwareUpdate_tests`: 26 passed, four new (URL derivation, malformed inputs, document wrapper with CSP, empty fragment)
- App builds; the dialog was driven in the built app via lldb with the `gen_html` output for 2.2.1 as the fixture: photo backdrop, white card, purple links, `#54`/`#55` as links, no citation noise; resized to 900×760 and the pane took all the growth, labels and buttons in place
- Live check path unchanged: `checkForUpdate:` against the real feed → "Up To Date" for 2.2.1
- 404 branch, live: fetch of `v2.2.1-undead/TextMate-2.2.1-undead-notes.html` → logged `No release notes at …: HTTP 404`, dialog unaffected
- `release.yml` parses; the new step sits between "Extract release notes" and "Create GitHub release", and the release gets both assets
- `docs/RELEASING.md` updated for the second asset; its "How users get the update" section still described `api.github.com` and now describes the ref-advertisement path

Not exercised: a live 200 fetch (no release carries the asset until this ships) and an actual click on a link in the pane.
