### PR TITLE
Replace std::iterator base classes with member typedefs

### DIFF
--- a/Frameworks/buffer/src/indexed_map.h
+++ b/Frameworks/buffer/src/indexed_map.h
@@ -38,8 +38,14 @@ private:
 	}
 
 public:
-	struct iterator : public std::iterator< std::bidirectional_iterator_tag, std::pair<ssize_t, _ValT> >
+	struct iterator
 	{
+		typedef std::bidirectional_iterator_tag iterator_category;
+		typedef std::pair<ssize_t, _ValT>       value_type;
+		typedef std::ptrdiff_t                  difference_type;
+		typedef std::pair<ssize_t, _ValT>*      pointer;
+		typedef std::pair<ssize_t, _ValT>&      reference;
+
 		iterator (tree_t& tree, typename tree_t::iterator const& base) : _tree(tree), _base(base) { update_value(); }
 
 		bool operator== (iterator const& rhs) const { return _base == rhs._base; }

--- a/Frameworks/buffer/src/storage.h
+++ b/Frameworks/buffer/src/storage.h
@@ -73,8 +73,14 @@ namespace ng
 				size_t _size;
 			};
 
-			struct iterator : public std::iterator<std::bidirectional_iterator_tag, value_t>
+			struct iterator
 			{
+				typedef std::bidirectional_iterator_tag iterator_category;
+				typedef value_t                         value_type;
+				typedef std::ptrdiff_t                  difference_type;
+				typedef value_t*                        pointer;
+				typedef value_t&                        reference;
+
 				iterator (typename oak::basic_tree_t<size_t, memory_t>::iterator base) : _base(base) { }
 				iterator (iterator const& rhs) : _base(rhs._base) { }
 				iterator& operator= (iterator const& rhs)   { _base = rhs._base; return *this; }

--- a/Frameworks/text/src/tokenize.h
+++ b/Frameworks/text/src/tokenize.h
@@ -6,8 +6,14 @@ namespace text
 	template <typename _ForwardIter, typename _CharT>
 	struct tokenize_helper_t
 	{
-		struct iterator : std::iterator<std::forward_iterator_tag, std::string, off_t>
+		struct iterator
 		{
+			typedef std::forward_iterator_tag iterator_category;
+			typedef std::string               value_type;
+			typedef off_t                     difference_type;
+			typedef std::string*              pointer;
+			typedef std::string&              reference;
+
 			iterator (_ForwardIter const& first, _ForwardIter const& last, _CharT delimiter, bool atEnd = false) : first(first), current(first), last(last), delimiter(delimiter), at_end(atEnd)
 			{
 				while(current != last && *current != delimiter)

--- a/Frameworks/text/src/utf8.h
+++ b/Frameworks/text/src/utf8.h
@@ -56,8 +56,14 @@ namespace utf8
 	}
 
 	template <typename _Iter>
-	struct iterator_t : public std::iterator<std::bidirectional_iterator_tag, uint32_t>
+	struct iterator_t
 	{
+		typedef std::bidirectional_iterator_tag iterator_category;
+		typedef uint32_t                        value_type;
+		typedef std::ptrdiff_t                  difference_type;
+		typedef uint32_t*                       pointer;
+		typedef uint32_t&                       reference;
+
 		typedef iterator_t self;
 
 		iterator_t (_Iter const& base_iterator) : base_iterator(base_iterator) { }
@@ -238,8 +244,14 @@ namespace utf8
 namespace diacritics
 {
 	template <typename _Iter>
-	struct iterator_t : public std::iterator<std::bidirectional_iterator_tag, uint32_t>
+	struct iterator_t
 	{
+		typedef std::bidirectional_iterator_tag iterator_category;
+		typedef uint32_t                        value_type;
+		typedef std::ptrdiff_t                  difference_type;
+		typedef uint32_t*                       pointer;
+		typedef uint32_t&                       reference;
+
 		typedef iterator_t self;
 
 		iterator_t (utf8::iterator_t<_Iter> const& first, utf8::iterator_t<_Iter> const& last) : current(first), stop(last) { }

--- a/Shared/include/oak/basic_tree.h
+++ b/Shared/include/oak/basic_tree.h
@@ -110,8 +110,14 @@ namespace oak
 		static bool eq (node_t* lhs, node_t* rhs) { return (lhs->is_null() && rhs->is_null()) || lhs == rhs; }
 
 	public:
-		struct iterator : std::iterator<std::bidirectional_iterator_tag, value_type>
+		struct iterator
 		{
+			typedef std::bidirectional_iterator_tag   iterator_category;
+			typedef typename basic_tree_t::value_type value_type;
+			typedef std::ptrdiff_t                    difference_type;
+			typedef value_type*                       pointer;
+			typedef value_type&                       reference;
+
 			iterator (node_t* node, basic_tree_t* tree) : _node(node), _info(_KeyT(), _node->_relative_key, _node->_value), _tree(tree) { }
 
 			bool operator== (iterator const& rhs) const { return  eq(_node, rhs._node); }


### PR DESCRIPTION
## Summary

First of three for #65. `std::iterator` is deprecated since C++17, and six iterator structs in widely-included headers derived from it — `oak/basic_tree.h`, `text/utf8.h` (two), `buffer/indexed_map.h`, `buffer/storage.h`, `text/tokenize.h`. Each inclusion repeated the warning: **242 of the 503 warning lines** in a clean Debug build of the `TextMate` target came from these six lines.

The base class only ever supplied the five iterator typedefs (`iterator_category`, `value_type`, `difference_type`, `pointer`, `reference`); they are now spelled out on each struct, with the same types the template arguments gave them (`tokenize.h` keeps its explicit `off_t` difference type). Nothing in the tree uses `iterator_traits` on these types.

## Testing

- Rebuilt the 103 translation units that include these headers plus every test suite: 0 `std::iterator`/libc++ deprecation lines remain (was 242)
- Full `ctest` run on this branch and on `origin/main` in the same build tree: **identical outcomes**, 17/27 in both. The ten that fail do so at baseline too and are environmental — `scm` wants `hg`/`svn`, `file`/`io` need fixtures and xattrs, `buffer` asserts on the spell checker, `cf`/`regexp`/`layout` abort under the Debug preset's AddressSanitizer inside the test code itself (`t_rect.cc:17` heap overflow, a stack-use-after-scope in the regexp tests). CI runs Release and already excludes `buffer|cf|command|editor|file|layout`.
- `text` passes; `buffer` fails identically before and after
